### PR TITLE
Increase the time capybara will wait for items before giving up

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ end
 # end
 
 Capybara.default_driver = :my_firefox_driver
+Capybara.default_max_wait_time = 30
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION

## Why was this change made?

Default value was 2 seconds which caused things like collection creation to fail occasionally


## Was the usage documentation (e.g. README) updated?
n/a