### PR TITLE
fix reaccession via preassembly spec

### DIFF
--- a/spec/features/reaccession_via_preassembly_spec.rb
+++ b/spec/features/reaccession_via_preassembly_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Reaccession from preassembly', type: :feature do
 
     fill_in 'Project name', with: "#{RandomWord.adjs.next}-#{RandomWord.nouns.next}"
     select 'Pre Assembly Run', from: 'Job type'
-    fill_in 'Bundle dir', with: '/dor/staging/integration-tests'
+    fill_in 'Bundle dir', with: '/dor/staging/integration-tests/reaccessioning-test'
     select 'Filename', from: 'Content metadata creation'
 
     click_button 'Submit'


### PR DESCRIPTION
## Why was this change made?

Since media accessioning also goes through preassembly, the files for a given test need to be in a subfolder or everything gets all confused.

and yes, I ran the test locally to ensure it works (and it was broken before since I started adding folders for audio-test and video-test)

## Was the usage documentation (e.g. README) updated?

na