### PR TITLE
use integration-testing apo and collection objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ You must be on VPN in order to run this script.
 `bundle exec rspec`
 
 You will be prompted to put in your credentials and then to approve a duo push.
+
+## Add New Tests
+
+Please use the integration-testing APO and collection when feasible:
+- integration-testing APO: qc410yz8746
+- integration-testing collection: bc778pm9866

--- a/spec/features/create_apo_spec.rb
+++ b/spec/features/create_apo_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Use Argo to create an administrative policy object', type: :feat
     object_type_element = find('dd.blacklight-objecttype_ssim')
     expect(object_type_element.text).to eq('adminPolicy')
 
-    # Wait for workflows to finish
+    # Wait for object to be accessioned
     Timeout.timeout(100) do
       loop do
         page.evaluate_script('window.location.reload()')

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -1,30 +1,17 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Use Argo to create a collection', type: :feature do
+RSpec.describe 'Use Argo to create a collection from APO page', type: :feature do
+  let(:integration_test_apo) { 'druid:qc410yz8746' }
   let(:collection_title) { RandomWord.phrases.next }
   let(:collection_abstract) { 'Created by https://github.com/sul-dlss/infrastructure-integration-test' }
-  let(:start_url) do
-    'https://argo-stage.stanford.edu/catalog?f%5BobjectType_ssim%5D%5B%5D=adminPolicy&f%5Bprocessing_status_text_ssi%5D%5B%5D=Accessioned'
-  end
+  let(:start_url) { "https://argo-stage.stanford.edu/view/#{integration_test_apo}" }
 
   before do
     authenticate!(start_url: start_url,
-                  expected_text: 'You searched for:')
+                  expected_text: 'integration-testing')
   end
 
-  scenario do
-    # Grab the first APO
-    within('#documents') do
-      first('h3 > a').click
-    end
-
-    # Make sure we're on an APO show view
-    expect(page).to have_content 'View in new window'
-    object_type_element = find('dd.blacklight-objecttype_ssim')
-    expect(object_type_element.text).to eq('adminPolicy')
-
-    apo_druid = find('dd.blacklight-id').text
-
+  it do
     click_link 'Create Collection'
 
     within('#blacklight-modal') do
@@ -44,9 +31,9 @@ RSpec.describe 'Use Argo to create a collection', type: :feature do
     expect(object_type_element.text).to eq('collection')
 
     apo_element = first('dd.blacklight-is_governed_by_ssim > a')
-    expect(apo_element[:href]).to end_with(apo_druid)
+    expect(apo_element[:href]).to end_with(integration_test_apo)
 
-    # Wait for workflows to finish
+    # Wait for object to be accessioned
     Timeout.timeout(100) do
       loop do
         page.evaluate_script('window.location.reload()')

--- a/spec/features/create_object_no_files_spec.rb
+++ b/spec/features/create_object_no_files_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Use Argo to create an object without any files', type: :feature do
+RSpec.describe 'Use Argo registration to create an object without any files', type: :feature do
   let(:random_word) { RandomWord.phrases.next }
   let(:object_label) { "Object Label for #{random_word}" }
   let(:start_url) { 'https://argo-stage.stanford.edu/' }
-  let(:source_id) { "test123:#{random_word}" }
+  let(:source_id) { "create-obj-no-files-test:#{random_word}" }
 
   before do
     authenticate!(start_url: start_url,
@@ -12,12 +12,13 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
   end
 
   scenario do
-    # Click on the Register drop-down
     click_link 'Register'
     click_link 'Register Items'
     expect(page).to have_content 'Register DOR Items'
 
-    # Add a row and fill source id and label fields
+    # fill in registration form
+    select 'integration-testing', from: 'Admin Policy'
+    select 'integration-testing', from: 'Collection'
     click_button 'Add Row'
 
     # Click Source ID and Label to add input
@@ -28,13 +29,10 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
     td_list[1].click
     fill_in '1_label', with: object_label
 
-    # Click on check-box to select row
+    # Click on check-box to select row, then enter to save
     find('#jqg_data_0').click
-
-    # Sends enter key to save
     find_field('1_label').send_keys :enter
 
-    # Clicks on Register Button
     find_button('Register').click
 
     # Searches for source id
@@ -46,7 +44,6 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
       end
     end
 
-    # Finds Druid and loads object's view
     object_druid = find('dd.blacklight-id').text
     visit "https://argo-stage.stanford.edu/view/#{object_druid}"
 
@@ -55,7 +52,7 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
     page.select 'accessionWF', from: 'wf'
     find_button('Add').click
 
-    # Wait for workflows to finish
+    # Wait for object to be accessioned
     Timeout.timeout(100) do
       loop do
         page.evaluate_script('window.location.reload()')

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'SDR deposit', type: :feature do
   let(:start_url) { 'https://argo-stage.stanford.edu/' }
   let(:api_url) { 'https://sdr-api-stage.stanford.edu' }
   let(:source_id) { "testing:#{SecureRandom.uuid}" }
-  let(:apo) { 'druid:sc012gz0974' }
-  let(:collection) { 'druid:hv320hk4091' }
+  let(:apo) { 'druid:qc410yz8746' }
+  let(:collection) { 'druid:bc778pm9866' }
   let(:catkey) { '10065784' }
 
   before do


### PR DESCRIPTION
## Why was this change made?

Whenever possible, our integration tests should 
- create collections from the integration-testing apo
- create objects in the integration-testing collection

This may not be comprehensive, but it's a good start. 

part of #46

## Was the usage documentation (e.g. README) updated?

na