### PR TITLE
Configure rubocop to allow large rspec blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,13 @@ Capybara/FeatureMethods:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/*.rb'
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+Metrics/BlockLength:
+  ExcludedMethods:
+    - describe
+    - it
+    - context
+    - scenario

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,21 +10,10 @@
 Metrics/AbcSize:
   Max: 22
 
-# Offense count: 15
-# Configuration parameters: CountComments, ExcludedMethods.
-# ExcludedMethods: refine
-Metrics/BlockLength:
-  Max: 199
-
 # Offense count: 2
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
   Max: 24
-
-# Offense count: 10
-# Configuration parameters: AggregateFailuresByDefault.
-RSpec/MultipleExpectations:
-  Max: 56
 
 # Offense count: 2
 Style/ClassVars:


### PR DESCRIPTION
## Why was this change made?
So we document our style expectations and don't have exceptions in the rubocop_todo.yml that we don't want to fix.


## Was the usage documentation (e.g. README) updated?
no.