### PR TITLE
remove needless waiting and navigation

### DIFF
--- a/spec/features/create_apo_spec.rb
+++ b/spec/features/create_apo_spec.rb
@@ -2,31 +2,27 @@
 
 RSpec.describe 'Use Argo to create an administrative policy object', type: :feature do
   let(:apo_title) { RandomWord.phrases.next }
-  let(:start_url) { 'https://argo-stage.stanford.edu/' }
+  let(:start_url) { 'https://argo-stage.stanford.edu/apo/new' }
 
   before do
-    authenticate!(start_url: start_url, expected_text: 'Welcome to Argo!')
+    expected_txt = 'The following defaults will apply to all newly registered objects.'
+    authenticate!(start_url: start_url, expected_text: expected_txt)
   end
 
   scenario do
-    # Activate the dropdown
-    click_link 'Register'
-    click_link 'Register APO'
-
-    expect(page).to have_content 'The following defaults will apply to all newly registered objects.'
-
     fill_in 'Title', with: apo_title
-    # TODO: More APO set-up steps
+    # TODO: More APO set-up steps / form fields exercised
     click_button 'Register APO'
 
-    # Make sure we're on an APO show view
+    # make sure we're on an APO show view
     expect(page).to have_content apo_title
+    # make sure APO is registered
     apo_druid = find('dd.blacklight-id').text
     expect(page).to have_content "APO #{apo_druid} created."
     object_type_element = find('dd.blacklight-objecttype_ssim')
     expect(object_type_element.text).to eq('adminPolicy')
 
-    # Wait for object to be accessioned
+    # wait for accessioningWF to finish
     Timeout.timeout(100) do
       loop do
         page.evaluate_script('window.location.reload()')

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Use Argo to create a collection from APO page', type: :feature d
     apo_element = first('dd.blacklight-is_governed_by_ssim > a')
     expect(apo_element[:href]).to end_with(integration_test_apo)
 
-    # Wait for object to be accessioned
+    # wait for accessioningWF to finish
     Timeout.timeout(100) do
       loop do
         page.evaluate_script('window.location.reload()')

--- a/spec/features/create_media_objects_spec.rb
+++ b/spec/features/create_media_objects_spec.rb
@@ -97,27 +97,17 @@ RSpec.describe 'Create new media objects via Pre-assembly', type: :feature do
     fill_in '2_source_id', with: video_source_id
     td_list[3].click
     fill_in '2_label', with: video_object_label
-    click_button('Lock')
+    find_field('2_label').send_keys :enter
     click_button('Register')
-
     # wait for objects to be registered
-    Timeout.timeout(100) do
-      loop do
-        fill_in 'q', with: "#{audio_source_id_random_word} #{audio_label_random_words}"
-        find_button('search').click
-        break if page.has_text?(audio_object_label) && page.has_text?('v1 Registered')
-      end
-    end
-    audio_druid = find('dd.blacklight-id').text.split(':').last
+    registered = find_all('td[aria-describedby=data_status][title=success]')
+    expect(registered.size).to eq 2
+    # get druids
+    druids = find_all('td[aria-describedby=data_druid]')
+    expect(druids.size).to eq 2
+    audio_druid = druids[0].text
+    video_druid = druids[1].text
     # puts "audio druid: #{audio_druid}" # useful for debugging
-    Timeout.timeout(100) do
-      loop do
-        fill_in 'q', with: "#{video_source_id_random_word} #{video_label_random_words}"
-        find_button('search').click
-        break if page.has_text?(video_object_label) && page.has_text?('v1 Registered')
-      end
-    end
-    video_druid = find('dd.blacklight-id').text.split(':').last
     # puts "video druid: #{video_druid}" # useful for debugging
 
     # Set up preassembly staging directories and files with druid in the name,
@@ -216,7 +206,7 @@ RSpec.describe 'Create new media objects via Pre-assembly', type: :feature do
       expect(page).to have_text("#{video_druid}_#{fname}")
     end
 
-    # Wait for accessioningWF to finish for video object
+    # wait for accessioningWF to finish for video object
     Timeout.timeout(100) do
       loop do
         page.evaluate_script('window.location.reload()')
@@ -225,7 +215,7 @@ RSpec.describe 'Create new media objects via Pre-assembly', type: :feature do
     end
     expect(page).to have_selector('.blacklight-content_type_ssim', text: 'media') # filled in by accessioning
 
-    # Wait for accessioningWF to finish for audio object
+    # wait for accessioningWF to finish for audio object
     visit "https://argo-stage.stanford.edu/view/#{audio_druid}"
     Timeout.timeout(100) do
       loop do


### PR DESCRIPTION
## Why was this change made?

To speed up tests;  
- no need to wait for registrationWF before using preassembly
- start from the url you really want in Argo

## Was the usage documentation (e.g. README) updated?

na