### PR TITLE
Set the preservation bit on the deposited files

### DIFF
--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -11,14 +11,17 @@ RSpec.describe 'SDR deposit', type: :feature do
 
   it 'deposits objects' do
     ensure_token
-
     result = SdrClient::Deposit.run(apo: APO,
                                     source_id: source_id,
                                     collection: COLLECTION,
                                     catkey: catkey,
                                     url: API_URL,
                                     accession: true,
-                                    files: ['Gemfile', 'Gemfile.lock'])
+                                    files: ['Gemfile', 'Gemfile.lock'],
+                                    files_metadata: {
+                                      'Gemfile' => { 'preserve' => true },
+                                      'Gemfile.lock' => { 'preserve' => true }
+                                    })
     object_druid = result[:druid]
 
     visit "#{start_url}view/#{object_druid}?beta=true"


### PR DESCRIPTION

## Why was this change made?

Technical metadata is only generated for preserved files now, so in order to make this test pass, we need to mark these files for preservation.


## Was the usage documentation (e.g. README) updated?
no