### PR TITLE
Set world access so that shelved files don't conflict with dark

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       nokogiri (>= 1.10.8)
       rubyzip (>= 1.3.0)
     rubyzip (2.3.0)
-    sdr-client (0.24.0)
+    sdr-client (0.25.0)
       activesupport
       cocina-models (~> 0.32.0)
       dry-monads

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'SDR deposit', type: :feature do
                                     catkey: catkey,
                                     url: API_URL,
                                     accession: true,
+                                    access: 'world',
                                     files: ['Gemfile', 'Gemfile.lock'],
                                     files_metadata: {
                                       'Gemfile' => { 'preserve' => true },


### PR DESCRIPTION


## Why was this change made?

The previous invocation is now tripping a validation in dor-services-app that disallows files to be shelved when the access is dark

## Was the usage documentation (e.g. README) updated?
no