### PR TITLE
Use config files instead of environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ spec/examples.txt
 tmp/manifest.csv
 tmp/media_manifest.csv
 downloads
+
+# config to hold sensitive values
+settings.local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'activesupport'
 gem 'byebug'
 gem 'capybara'
+gem 'config'
 gem 'faraday' # etds require POST request from registrar
 gem 'pry-byebug'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,10 @@ GEM
     commonmarker (0.21.0)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.6)
+    config (2.2.1)
+      deep_merge (~> 1.2, >= 1.2.1)
+      dry-validation (~> 1.0, >= 1.0.0)
+    deep_merge (1.2.1)
     diff-lcs (1.3)
     dry-configurable (0.11.5)
       concurrent-ruby (~> 1.0)
@@ -44,6 +48,7 @@ GEM
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
+    dry-initializer (3.0.3)
     dry-logic (1.0.6)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.2)
@@ -52,6 +57,14 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer
+    dry-schema (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.8, >= 0.8.3)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.0)
+      dry-types (~> 1.4)
     dry-struct (1.3.0)
       dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer (~> 0.3)
@@ -64,6 +77,13 @@ GEM
       dry-equalizer (~> 0.3)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
+    dry-validation (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.5)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     i18n (1.8.2)
@@ -152,6 +172,7 @@ DEPENDENCIES
   activesupport
   byebug
   capybara
+  config
   faraday
   pry-byebug
   rake

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Host *.stanford.edu
 
 ### ETD Credentials
 
-In order to run the tests in `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application. In order to do this, set the following two environment variables: `ETD_POST_USERNAME` and `ETD_POST_PASSWORD`. You can find the correct values for our staging environment in the shared_configs repository.
+In order to run the tests in `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application. In order to do this, copy `settings.yml` to `settings.local.yml` and set the ETD username and password to the [values expected in our staging environment](https://github.com/sul-dlss/shared_configs/blob/a90c636b968a1ede4886a61dadc799dd5d162fe1/config/settings/production.yml#L34-L35).
+
+**NOTE**: `settings.local.yml` is ignored by git and should remain so. Please do not accidentally add this file to version control.
 
 ## Run Tests
 

--- a/settings.yml
+++ b/settings.yml
@@ -1,0 +1,3 @@
+etd:
+  username: ~
+  password: ~

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -233,9 +233,9 @@ RSpec.describe 'Create a new ETD', type: :feature do
 end
 
 def simulate_registrar_post(xml)
-  @user ||= ENV['ETD_POST_USERNAME']
-  @password ||= ENV['ETD_POST_PASSWORD']
-  conn = Faraday.new(url: "https://#{@user}:#{@password}@#{etd_base_url}/etds")
+  username = Settings.etd.username
+  password = Settings.etd.password
+  conn = Faraday.new(url: "https://#{username}:#{password}@#{etd_base_url}/etds")
   resp = conn.post do |req|
     req.options.timeout = 10
     req.options.open_timeout = 10

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'config'
+
+# NOTE: For some reason `File.expand_path(__dir__, '../..')` did not do the right thing.
+app_root = Pathname.new(__dir__).parent.parent
+
+Config.load_and_set_settings(
+  Config.setting_files(app_root, 'local')
+)


### PR DESCRIPTION
Yes, I ran the spec and verified that it works as expected!

## Why was this change made?

This lets us use a single file to store credentials locally so we can set it up once and move on, rather than having to fuss about with environment variables. Thanks to @ndushay for the recommendation!


## Was the usage documentation (e.g. README) updated?

Yes.