### PR TITLE
make the default rake task running all the tests with rubocop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ cache: bundler
 before_install:
   - yes | gem update --system
 
+script:
+  - bundle exec rake rubocop
+
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ In order to run the tests in `spec/features/create_etd_spec.rb`, you will need t
 
 `bundle exec rspec`
 
+or to run with rubocop, use the default rake task:
+
+`bundle exec rake`
+
 You will be prompted to type in your Stanford credentials and will then need to approve a multi-factor authentication push.
 
 ### Timeouts

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,10 @@
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: [:rubocop]
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
+task default: [:rubocop, :spec]


### PR DESCRIPTION
## Why was this change made?

Default rake task runs the test to match other projects; but travis should still only run rubocop

## Was the usage documentation (e.g. README) updated?

yes