### PR TITLE
Allow switching between Firefox and Chrome selenium drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 capybara-*.html
 geckodriver*
+chromedriver*
 
 spec/examples.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 capybara-*.html
-geckodriver*
-chromedriver*
 
 spec/examples.txt
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,4 @@ gem 'rubocop-rspec'
 gem 'rubyXL' # for updating Excel spreadsheets
 gem 'selenium-webdriver'
 gem 'sdr-client', '~> 0.22'
+gem 'webdrivers', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,10 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
+    webdrivers (4.3.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -183,6 +187,7 @@ DEPENDENCIES
   rubyXL
   sdr-client (~> 0.22)
   selenium-webdriver
+  webdrivers (~> 4.0)
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -11,16 +11,12 @@ This script depends on having Firefox or Chrome downloaded.
 ### Using Firefox (default)
 
 1. `bundle install`
-1. Download geckodriver `curl -L --output geckodriver-v0.26.0-macos.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-macos.tar.gz`
-1. Uncompress it `tar -zxvf geckodriver-v0.26.0-macos.tar.gz`
-1. Put geckodriver on the path `export PATH=$PATH:$(pwd)`
+1. `rake webdrivers:geckodriver:update`
 
 ### Using Chrome
 
 1. `bundle install`
-1. Download chromedriver per these instructions: https://chromedriver.chromium.org/downloads
-1. Uncompress it: `unzip chromedriver_linux64.zip`
-1. Put chromedriver on the path: `export PATH=$PATH:$(pwd)`
+1. `rake webdrivers:chromedriver:update`
 1. Set `webdriver` to `chrome` in `settings.local.yml`
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ This script drives a browser to do inter-system integration testing of SDR in th
 
 ## Installation
 
-This script depends on having Firefox downloaded.
+This script depends on having Firefox or Chrome downloaded.
+
+### Using Firefox (default)
 
 1. `bundle install`
 1. Download geckodriver `curl -L --output geckodriver-v0.26.0-macos.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-macos.tar.gz`
 1. Uncompress it `tar -zxvf geckodriver-v0.26.0-macos.tar.gz`
 1. Put geckodriver on the path `export PATH=$PATH:$(pwd)`
+
+### Using Chrome
+
+1. `bundle install`
+1. Download chromedriver per these instructions: https://chromedriver.chromium.org/downloads
+1. Uncompress it: `unzip chromedriver_linux64.zip`
+1. Put chromedriver on the path: `export PATH=$PATH:$(pwd)`
+1. Set `webdriver` to `chrome` in `settings.local.yml`
 
 ## Prerequisites
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'webdrivers'
+load 'webdrivers/Rakefile'
+
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 

--- a/settings.yml
+++ b/settings.yml
@@ -1,9 +1,13 @@
 etd:
   username: ~
   password: ~
+
 timeouts:
   capybara: 30
   workflow: 100
+
 sunet:
   id: ~
   password: ~
+
+webdriver: firefox

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'random_word'
 require 'rubyXL'
 require 'sdr-client'
 require 'selenium-webdriver'
+require 'webdrivers'
 
 root = Pathname.new(File.expand_path('../', __dir__))
 Dir[root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,8 @@ Dir[root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 Capybara.run_server = false
 
-browser_options = ::Selenium::WebDriver::Firefox::Options.new
-browser_options.profile = Selenium::WebDriver::Firefox::Profile.new.tap do |profile|
+firefox_options = ::Selenium::WebDriver::Firefox::Options.new
+firefox_options.profile = Selenium::WebDriver::Firefox::Profile.new.tap do |profile|
   profile['browser.download.dir'] = DownloadHelpers::PATH.to_s
   # profile["browser.helperApps.neverAsk.openFile"] = "application/x-yaml"
   profile['browser.download.folderList'] = 2
@@ -23,16 +23,21 @@ browser_options.profile = Selenium::WebDriver::Firefox::Profile.new.tap do |prof
 end
 
 Capybara.register_driver :my_firefox_driver do |app|
-  Capybara::Selenium::Driver.new(app, browser: :firefox, options: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: firefox_options)
 end
 
-# Capybara.register_driver :chrome do |app|
-#   Capybara::Selenium::Driver.new(app, browser: :chrome).tap do |driver|
-#     driver.browser.download_path = DownloadHelpers::PATH.to_s
-#   end
-# end
+Capybara.register_driver :my_chrome_driver do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome).tap do |driver|
+    driver.browser.download_path = DownloadHelpers::PATH.to_s
+  end
+end
 
-Capybara.default_driver = :my_firefox_driver
+Capybara.default_driver = case Settings.webdriver
+                          when 'chrome'
+                            :my_chrome_driver
+                          else
+                            :my_firefox_driver
+                          end
 Capybara.default_max_wait_time = Settings.timeouts.capybara
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
Also:

* Prefer webdrivers gem over manual downloading of drivers

## Why was this change made?

To allow individual developers to exert more control over which browser is used for integration testing. Important especially when a driver (e.g. geckodriver w/ Firefox 76) is misbehaving.

And to remove manual set up steps.

## How was this change tested?

I ran the suite twice, once with each driver. It ran the tests as expected. None of the failures noted were due to changes in this branch, AFAICT.

## Which documentation and/or configurations were updated?

README.

