### PR TITLE
Bump up timeouts

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -3,8 +3,8 @@ etd:
   password: ~
 
 timeouts:
-  capybara: 30
-  workflow: 100
+  capybara: 60
+  workflow: 200
 
 sunet:
   id: ~ # NOTE: *without* @stanford.edu!


### PR DESCRIPTION
## Why was this change made?

All eleven tests pass for me (using ffx driver, not chrome) when I bump these values up in `settings.local.yml`. That suggests to me we ought to consider setting these as the defaults.

## Was README.md updated if necessary?

No.

## Are there any configuration changes for shared_configs?

No.