### PR TITLE
Remove support for chrome driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,10 @@ This script drives a browser to do inter-system integration testing of SDR in th
 
 ## Installation
 
-This script depends on having Firefox or Chrome downloaded.
-
-### Using Firefox (default)
+This script depends on having Firefox downloaded.
 
 1. `bundle install`
 1. `rake webdrivers:geckodriver:update`
-
-### Using Chrome
-
-1. `bundle install`
-1. `rake webdrivers:chromedriver:update`
-1. Set `browser.driver` to `chrome` in `settings.local.yml`
 
 ### Browser Window Size
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,22 +30,7 @@ Capybara.register_driver :my_firefox_driver do |app|
   Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
 end
 
-Capybara.register_driver :my_chrome_driver do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(
-    args: ["window-size=#{Settings.browser.width},#{Settings.browser.height}"]
-  )
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options).tap do |driver|
-    driver.browser.download_path = DownloadHelpers::PATH.to_s
-  end
-end
-
-Capybara.default_driver = case Settings.browser.driver
-                          when 'chrome'
-                            :my_chrome_driver
-                          else
-                            :my_firefox_driver
-                          end
+Capybara.default_driver = :my_firefox_driver
 Capybara.default_max_wait_time = Settings.timeouts.capybara
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
Fixes #103

## Why was this change made?

Our tests do not all pass using the Chrome browser. Use Firefox for all tests to reduce variation.

## Was README.md updated if necessary?

Yes

## Are there any configuration changes for shared_configs?

No