### PR TITLE
Set a small capybara timeout when inside a refresh loop

### DIFF
--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'Create a new ETD', type: :feature do
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
         visit "https://argo-stage.stanford.edu/view/#{prefixed_druid}"
-        break if page.has_text?('This item is embargoed until')
+        break if page.has_text?('This item is embargoed until', wait: 1)
       end
     end
     expect(page).to have_content(dissertation_title)

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -11,9 +11,9 @@ module PageHelpers
         # NOTE: This could have been a ternary but I was concerned about its
         #       readability.
         if as_link
-          break if page.has_link?(text)
+          break if page.has_link?(text, wait: 1)
         else
-          break if page.has_text?(text)
+          break if page.has_text?(text, wait: 1)
         end
       end
     end


### PR DESCRIPTION


## Why was this change made?
Otherwise it waits for the capybara timeout to expire before looping, causing the whole suite to be very slow
## Was README.md updated if necessary?

no

## Are there any configuration changes for shared_configs?
no