### PR TITLE
Allow running tests in both staging and QA environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ tmp/manifest.csv
 tmp/media_manifest.csv
 downloads
 
-# config to hold sensitive values
-settings.local.yml
+# configs to hold sensitive values
+*.local.yml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SDR Integration Tests
 
-This script drives a browser to do inter-system integration testing of SDR in the staging environment.
+This script drives a browser to do inter-system integration testing of SDR in the staging or QA environment.
 
 ## Installation
 
@@ -17,11 +17,11 @@ This script depends on having Firefox or Chrome downloaded.
 
 1. `bundle install`
 1. `rake webdrivers:chromedriver:update`
-1. Set `browser.driver` to `chrome` in `settings.local.yml`
+1. Set `browser.driver` to `chrome` in `config/settings.local.yml`
 
 ### Browser Window Size
 
-If you find you need to modify the default window size for either browser, copy the default settings for `browser.height` and `browser.width` from `settings.yml` to `settings.local.yml` and modify them to meet your needs.
+If you find you need to modify the default window size for either browser, copy the default settings for `browser.height` and `browser.width` from `config/settings.yml` to `config/settings.local.yml` and modify them to meet your needs.
 
 ## Prerequisites
 
@@ -37,13 +37,23 @@ Host *.stanford.edu
 
 ### SUNet Credentials
 
-If you tire of typing in your SUNet credentials over and over, you may add them to `settings.local.yml` (ignored by git). Copy the dummy values from `settings.yml` to get started. Do *not* add this file to version control, if you do this!
+If you tire of typing in your SUNet credentials over and over, you may add them to `config/settings.local.yml` (ignored by git). Copy the dummy values from `config/settings.yml` to get started. Do *not* add this file to version control, if you do this!
 
 ### ETD Credentials
 
-In order to run the tests in `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application. In order to do this, copy `settings.yml` to `settings.local.yml` and set the ETD username and password to the [values expected in our staging environment](https://github.com/sul-dlss/shared_configs/blob/a90c636b968a1ede4886a61dadc799dd5d162fe1/config/settings/production.yml#L34-L35).
+In order to run the tests in `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application.
 
-**NOTE**: `settings.local.yml` is ignored by git and should remain so. Please do not accidentally add this file to version control.
+#### Staging Environment
+
+For the staging environment, copy `config/settings.yml` to `config/settings/staging.local.yml` and set the ETD username and password to the [values expected in our staging environment](https://github.com/sul-dlss/shared_configs/blob/a90c636b968a1ede4886a61dadc799dd5d162fe1/config/settings/production.yml#L34-L35).
+
+**NOTE**: `config/settings/staging.local.yml` is ignored by git and should remain so. Please do not accidentally add this file to version control.
+
+#### QA Environment
+
+For the QA environment, copy `config/settings.yml` to `config/settings/qa.local.yml` and set the ETD username and password to the [values expected in our QA environment](https://github.com/sul-dlss/shared_configs/blob/59ead7acbdf351930ad45922fd44e0f45810bf37/config/settings/production.yml#L16-L17).
+
+**NOTE**: `config/settings/qa.local.yml` is ignored by git and should remain so. Please do not accidentally add this file to version control.
 
 ## Run Tests
 
@@ -58,6 +68,14 @@ You will be prompted to type in your Stanford credentials and will then need to 
 ### Timeouts
 
 If you are experiencing timeout errors, you may override the default Capybara and workflow-related timeout values by adding `timeouts.capybara` and/or `timeouts.workflow` in `config/settings.local.yml`.
+
+### SDR Environments
+
+By default, the integration tests run in the SDR staging environment. To test in the SDR QA environment, run tests with the `SDR_ENV` environment variable, like so:
+
+```shell
+SDR_ENV=qa bundle exec rspec
+```
 
 ## Add New Tests
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,6 @@ browser:
   driver: firefox
   height: 900
   width: 1440
+
+default_apo: 'druid:qc410yz8746'
+default_collection: 'druid:bc778pm9866'

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,0 +1,7 @@
+argo_url: 'https://argo-qa.stanford.edu'
+etd_url: 'https://etd-qa.stanford.edu'
+hydrus_url: 'https://sdr-qa.stanford.edu'
+preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
+preassembly_host: 'sul-preassembly-qa'
+preassembly_url: 'https://sul-preassembly-qa.stanford.edu'
+sdrapi_url: 'https://sdr-api-qa.stanford.edu'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,0 +1,7 @@
+argo_url: 'https://argo-stage.stanford.edu'
+etd_url: 'https://etd-stage.stanford.edu'
+hydrus_url: 'https://sdr-test.stanford.edu'
+preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
+preassembly_host: 'sul-preassembly-stage'
+preassembly_url: 'https://sul-preassembly-stage.stanford.edu'
+sdrapi_url: 'https://sdr-api-stage.stanford.edu'

--- a/spec/features/bulk_update_metadata_spec.rb
+++ b/spec/features/bulk_update_metadata_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
   let(:note) { RandomWord.phrases.next }
 
   before do
-    authenticate!(start_url: BASE_URL, expected_text: 'Welcome to Argo!')
+    authenticate!(start_url: Settings.argo_url, expected_text: 'Welcome to Argo!')
   end
 
   scenario do
@@ -14,16 +14,16 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
     druid2 = create_druid
     temp_xlsx = update_xlsx(druid1, title1, druid2, title2)
 
-    visit("#{BASE_URL}view/#{APO}")
-    # Opens the MODS bulk jobs
+    visit "#{Settings.argo_url}/view/#{Settings.default_apo}"
+    # Open the MODS bulk jobs
     click_link 'MODS bulk loads'
     expect(page).to have_content 'Datastream spreadsheet bulk upload for APO'
 
-    # Opens the Submit new file modal
+    # Open the Submit new file modal
     click_link 'Submit new file ...'
     expect(page).to have_content 'Submit MODS descriptive metadata for bulk processing'
 
-    # Attaches spreadsheet fixture, selects spreadsheet input, and adds note
+    # Attach spreadsheet fixture, select spreadsheet input, and add note
     attach_file('Select', temp_xlsx.path)
     choose 'Spreadsheet input; load into objects'
     fill_in '3. Note', with: note
@@ -31,9 +31,9 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
 
     reload_page_until_timeout!(text: note)
 
-    # Delete's job run
+    # Delete job run
     job_rows = page.find_all('div#bulk-upload-table > table > tbody > tr')
-    job_rows.drop(1).each do |row|
+    job_rows.each do |row|
       tds = row.find_all('td')
       next unless tds[3].text == note
 
@@ -42,13 +42,13 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
       click_link 'Delete'
       break
     end
-    expect(page).to have_content "Bulk job for APO (#{APO}) deleted."
+    expect(page).to have_content "Bulk job for APO (#{Settings.default_apo}) deleted."
 
     # Open druids and tests for titles
-    visit("#{BASE_URL}view/#{druid1}")
-    expect(page).to have_content title1
+    visit "#{Settings.argo_url}/view/#{druid1}"
+    reload_page_until_timeout!(text: title1)
 
-    visit("#{BASE_URL}view/#{druid2}")
-    expect(page).to have_content title2
+    visit "#{Settings.argo_url}/view/#{druid2}"
+    reload_page_until_timeout!(text: title2)
   end
 end

--- a/spec/features/create_apo_spec.rb
+++ b/spec/features/create_apo_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'Use Argo to create an administrative policy object', type: :feature do
   let(:apo_title) { RandomWord.phrases.next }
-  let(:start_url) { 'https://argo-stage.stanford.edu/apo/new' }
+  let(:start_url) { "#{Settings.argo_url}/apo/new" }
 
   before do
     expected_txt = 'The following defaults will apply to all newly registered objects.'

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -3,14 +3,14 @@
 RSpec.describe 'Use Argo to create a collection from APO page', type: :feature do
   let(:collection_title) { RandomWord.phrases.next }
   let(:collection_abstract) { 'Created by https://github.com/sul-dlss/infrastructure-integration-test' }
-  let(:start_url) { "https://argo-stage.stanford.edu/view/#{APO}" }
+  let(:start_url) { "#{Settings.argo_url}/view/#{Settings.default_apo}" }
 
   before do
     authenticate!(start_url: start_url,
                   expected_text: 'integration-testing')
   end
 
-  it do
+  scenario do
     click_link 'Create Collection'
 
     within('#blacklight-modal') do
@@ -22,7 +22,7 @@ RSpec.describe 'Use Argo to create a collection from APO page', type: :feature d
     expect(page).to have_content 'Created collection'
 
     collection_druid = find('.alert-info').text.split[2]
-    visit "https://argo-stage.stanford.edu/view/#{collection_druid}"
+    visit "#{Settings.argo_url}/view/#{collection_druid}"
 
     expect(page).to have_content collection_title
 
@@ -30,7 +30,7 @@ RSpec.describe 'Use Argo to create a collection from APO page', type: :feature d
     expect(object_type_element.text).to eq('collection')
 
     apo_element = first('dd.blacklight-is_governed_by_ssim > a')
-    expect(apo_element[:href]).to end_with(APO)
+    expect(apo_element[:href]).to end_with(Settings.default_apo)
 
     # wait for accessioningWF to finish
     reload_page_until_timeout!(text: 'v1 Accessioned')

--- a/spec/features/create_object_no_files_spec.rb
+++ b/spec/features/create_object_no_files_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'Use Argo to create an object without any files', type: :feature do
   let(:random_word) { RandomWord.phrases.next }
   let(:object_label) { "Object Label for #{random_word}" }
-  let(:start_url) { 'https://argo-stage.stanford.edu/registration' }
+  let(:start_url) { "#{Settings.argo_url}/registration" }
   let(:source_id) { "create-obj-no-files-test:#{random_word}" }
 
   before do
@@ -29,7 +29,7 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
     object_druid = find('td[aria-describedby=data_druid]').text
     # puts "object_druid: #{object_druid}" # useful for debugging
 
-    visit "https://argo-stage.stanford.edu/view/#{object_druid}"
+    visit "#{Settings.argo_url}/view/#{object_druid}"
 
     # wait for registrationWF to finish
     reload_page_until_timeout!(text: 'v1 Registered')

--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 # Preassembly requires that files to be included in an object must be available on a mounted drive
-# To this end, files have been placed on preassembly-stage at /dor/staging/integration-tests/image-test
+# To this end, files have been placed on Settings.preassembly_host at Settings.preassembly_bundle_directory
 RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature do
   druid = '' # used for HEREDOC preassembly manifest files (can't be memoized)
 
-  let(:start_url) { 'https://argo-stage.stanford.edu/registration' }
-  let(:preassembly_bundle_dir) { '/dor/staging/integration-tests/image-test' }
-  let(:remote_manifest_location) { "preassembly@sul-preassembly-stage:#{preassembly_bundle_dir}" }
+  let(:start_url) { "#{Settings.argo_url}/registration" }
+  let(:preassembly_bundle_dir) { Settings.preassembly_bundle_directory }
+  let(:remote_manifest_location) { "preassembly@#{Settings.preassembly_host}:#{preassembly_bundle_dir}" }
   let(:local_manifest_location) { 'tmp/manifest.csv' }
   let(:preassembly_project_name) { "IntegrationTest-preassembly-image-#{RandomWord.nouns.next}" }
   let(:source_id_random_word) { "#{RandomWord.adjs.next}-#{RandomWord.nouns.next}" }
@@ -30,7 +30,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
     clear_downloads
   end
 
-  it do
+  scenario do
     # register new object
     select 'integration-testing', from: 'Admin Policy'
     select 'integration-testing', from: 'Collection'
@@ -57,7 +57,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
       raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
     end
 
-    visit 'https://sul-preassembly-stage.stanford.edu/'
+    visit Settings.preassembly_url
     expect(page).to have_selector('h3', text: 'Complete the form below')
 
     fill_in 'Project name', with: preassembly_project_name
@@ -82,7 +82,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
     expect(yaml[:status]).to eq 'success'
 
     # ensure Image files are all there, per pre-assembly, organized into specified resources
-    visit "https://argo-stage.stanford.edu/view/#{druid}"
+    visit "#{Settings.argo_url}/view/#{druid}"
     expect(page).to have_selector('#document-contents-section > .resource-list > li.resource', text: 'Resource (1) image')
     expect(page).to have_selector('#document-contents-section > .resource-list > li', text: 'Image 1')
     files = all('li.file')
@@ -102,7 +102,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
     md = /^v(\d+) Accessioned/.match(elem.text)
     version = md[1].to_i
 
-    visit 'https://sul-preassembly-stage.stanford.edu/'
+    visit Settings.preassembly_url
 
     expect(page).to have_content 'Complete the form below'
 
@@ -127,7 +127,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
     yaml = YAML.load_file(download)
     expect(yaml[:status]).to eq 'success'
 
-    visit "https://argo-stage.stanford.edu/view/druid:#{yaml[:pid]}"
+    visit "#{Settings.argo_url}/view/druid:#{yaml[:pid]}"
 
     reload_page_until_timeout!(text: "v#{version + 1} Accessioned")
   end

--- a/spec/features/deposit_via_hydrus_spec.rb
+++ b/spec/features/deposit_via_hydrus_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'Use Hydrus to deposit an item', type: :feature do
   let(:collection_title) { RandomWord.nouns.next }
   let(:item_title) { RandomWord.nouns.next }
-  let(:start_url) { 'https://sdr-test.stanford.edu/webauth/login?referrer=/' }
+  let(:start_url) { "#{Settings.hydrus_url}/webauth/login?referrer=/" }
   let(:user_email) { "#{AuthenticationHelpers.class_variable_get(:@@username)}@stanford.edu" }
 
   before do
@@ -66,7 +66,7 @@ RSpec.describe 'Use Hydrus to deposit an item', type: :feature do
     expect(page).to have_content 'Collection closed'
     expect(page).to have_content 'Closed for deposit'
 
-    visit "https://argo-stage.stanford.edu/view/#{collection_druid}"
+    visit "#{Settings.argo_url}/view/#{collection_druid}"
     expect(page).to have_content('View in new window')
 
     # page does not initially display title, loop until reindexed
@@ -75,7 +75,7 @@ RSpec.describe 'Use Hydrus to deposit an item', type: :feature do
     expect(find('dd.blacklight-tag_ssim').text).to include 'Project : Hydrus'
     expect(find('dd.blacklight-project_tag_ssim').text).to eq 'Hydrus'
 
-    visit "https://argo-stage.stanford.edu/view/#{item_druid}"
+    visit "#{Settings.argo_url}/view/#{item_druid}"
 
     # page does not initially display title, loop until reindexed
     reload_page_until_timeout!(text: "Stanford, Jane Lathrop #{item_title}: 2000-01-01")

--- a/spec/features/edit_bulk_tags_spec.rb
+++ b/spec/features/edit_bulk_tags_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Use Argo to edit administrative tags in bulk', type: :feature do
-  let(:start_url) { 'https://argo-stage.stanford.edu/catalog?f%5Bexploded_tag_ssim%5D%5B%5D=Registered+By' }
+  let(:start_url) { "#{Settings.argo_url}/catalog?f%5Bexploded_tag_ssim%5D%5B%5D=Registered+By" }
   let(:export_tag_description) { RandomWord.phrases.next }
   let(:import_tag_description) { RandomWord.phrases.next }
   let(:number_of_druids) { 3 }
@@ -112,13 +112,13 @@ RSpec.describe 'Use Argo to edit administrative tags in bulk', type: :feature do
       end
     end
 
-    visit "https://argo-stage.stanford.edu/view/#{druid_with_added_tag.first}"
+    visit "#{Settings.argo_url}/view/#{druid_with_added_tag.first}"
     expect(page).to have_content(added_tag)
 
-    visit "https://argo-stage.stanford.edu/view/#{druid_with_removed_tag.first}"
+    visit "#{Settings.argo_url}/view/#{druid_with_removed_tag.first}"
     expect(page).not_to have_content(removed_tag)
 
-    visit "https://argo-stage.stanford.edu/view/#{druid_with_changed_tag.first}"
+    visit "#{Settings.argo_url}/view/#{druid_with_changed_tag.first}"
     expect(page).to have_content(edited_tag)
     expect(page).not_to have_content(replaced_tag)
   end

--- a/spec/features/edit_item_tags_spec.rb
+++ b/spec/features/edit_item_tags_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'Use Argo to edit administrative tags for a single item', type: :feature do
   let(:start_url) do
-    'https://argo-stage.stanford.edu/catalog?f%5BobjectType_ssim%5D%5B%5D=item&f%5Bprocessing_status_text_ssi%5D%5B%5D=Accessioned'
+    "#{Settings.argo_url}/catalog?f%5BobjectType_ssim%5D%5B%5D=item&f%5Bprocessing_status_text_ssi%5D%5B%5D=Accessioned"
   end
 
   before do

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'SDR deposit', type: :feature do
-  let(:start_url) { 'https://argo-stage.stanford.edu/' }
+  let(:start_url) { Settings.argo_url }
   let(:source_id) { "testing:#{SecureRandom.uuid}" }
   let(:catkey) { '10065784' }
 
@@ -11,9 +11,9 @@ RSpec.describe 'SDR deposit', type: :feature do
 
   it 'deposits objects' do
     ensure_token
-    object_druid = deposit(apo: APO,
-                           collection: COLLECTION,
-                           url: API_URL,
+    object_druid = deposit(apo: Settings.default_apo,
+                           collection: Settings.default_collection,
+                           url: Settings.sdrapi_url,
                            source_id: source_id,
                            catkey: catkey,
                            accession: true,
@@ -24,7 +24,7 @@ RSpec.describe 'SDR deposit', type: :feature do
                              'Gemfile.lock' => { 'preserve' => true }
                            })
 
-    visit "#{start_url}view/#{object_druid}?beta=true"
+    visit "#{start_url}/view/#{object_druid}?beta=true"
 
     # Wait for indexing and workflows to finish
     reload_page_until_timeout!(text: 'v1 Accessioned')

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -28,7 +28,7 @@ module AuthenticationHelpers
 
   def ensure_token
     @@token ||= begin
-      visit "#{BASE_URL}/settings/tokens"
+      visit "#{Settings.argo_url}/settings/tokens"
       click_button 'Generate new token'
       find_field('Token').value.tap do |token|
         SdrClient::Credentials.write(token)

--- a/spec/support/config.rb
+++ b/spec/support/config.rb
@@ -3,8 +3,9 @@
 require 'config'
 
 # NOTE: For some reason `File.expand_path(__dir__, '../..')` did not do the right thing.
-app_root = Pathname.new(__dir__).parent.parent
+app_root = Pathname.new(__dir__).parent.parent + 'config'
+env = ENV.fetch('SDR_ENV', 'staging')
 
 Config.load_and_set_settings(
-  Config.setting_files(app_root, 'local')
+  Config.setting_files(app_root, env)
 )

--- a/spec/support/constants.rb
+++ b/spec/support/constants.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-APO = 'druid:qc410yz8746'
-API_URL = 'https://sdr-api-stage.stanford.edu'
-COLLECTION = 'druid:bc778pm9866'
-BASE_URL = 'https://argo-stage.stanford.edu/'

--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -9,7 +9,7 @@ module DepositHelpers
 
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
-        result = SdrClient::BackgroundJobResults.show(url: API_URL, job_id: job_id)
+        result = SdrClient::BackgroundJobResults.show(url: Settings.sdrapi_url, job_id: job_id)
         raise result[:output][:errors] if result[:output][:errors].present?
 
         object_druid = result[:output][:druid]

--- a/spec/support/xlsx_helpers.rb
+++ b/spec/support/xlsx_helpers.rb
@@ -9,11 +9,11 @@ module XlsxHelpers
 
     ensure_token
     deposit(
-      apo: APO,
+      apo: Settings.default_apo,
       source_id: source_id,
       label: object_label,
-      collection: COLLECTION,
-      url: API_URL
+      collection: Settings.default_collection,
+      url: Settings.sdrapi_url
     )
   end
 


### PR DESCRIPTION
Connects to #128

I can confirm that all the tests passed for me (after a couple runs, per usual).

## Why was this change made?

To allow running tests in staging and QA per #128.

## Was README.md updated if necessary?

Yes.

## Are there any configuration changes for shared_configs?

Not shared_configs, no, but local configs have been modified and documented.