### PR TITLE
create_etd: change due to hydra_etd PR 666

### DIFF
--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Create a new ETD', type: :feature do
     # indicate copyrighted material
     expect(page).to have_selector('#pbPermissionsProvided', text: "Copyrighted material checked\n- Not done")
     expect(find('#pbPermissionsProvided')['style']).to eq '' # rights not yet selected
-    select 'does include', from: 'selectPermissionsOptions'
+    select 'Yes', from: 'My thesis contains copyright material'
 
     # provide copyright permissions letters/files
     expect(page).not_to have_content(permissions_filename)


### PR DESCRIPTION
## Why was this change made?

So create_etd test would run cleanly after PR sul-dlss/hydra_etd#666 is deployed to stage

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

n/a