### PR TITLE
Find bulk update row without looping

### DIFF
--- a/spec/features/bulk_update_metadata_spec.rb
+++ b/spec/features/bulk_update_metadata_spec.rb
@@ -32,16 +32,11 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
     reload_page_until_timeout!(text: note)
 
     # Delete job run
-    job_rows = page.find_all('div#bulk-upload-table > table > tbody > tr')
-    job_rows.each do |row|
-      tds = row.find_all('td')
-      next unless tds[3].text == note
-
-      tds[9].find('form > button').click
-      # Confirm delete in the popup
-      click_link 'Delete'
-      break
-    end
+    row = page.find(:xpath, "//div[@id='bulk-upload-table']//tr[td/text()='#{note}']")
+    tds = row.all('td')
+    tds[9].find('form > button').click
+    # Confirm delete in the popup
+    click_link 'Delete'
     expect(page).to have_content "Bulk job for APO (#{Settings.default_apo}) deleted."
 
     # Open druids and tests for titles

--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
 
     # ensure Image files are all there, per pre-assembly, organized into specified resources
     visit "#{Settings.argo_url}/view/#{druid}"
-    expect(page).to have_selector('#document-contents-section > .resource-list > li.resource', text: 'Resource (1) image')
+    reload_page_until_timeout!(text: 'Resource (1) image')
     expect(page).to have_selector('#document-contents-section > .resource-list > li', text: 'Image 1')
     files = all('li.file')
     expect(files.size).to eq 2


### PR DESCRIPTION
## Why was this change made?

Includes:

* Squash a bug I introduced due to treating a row of TH elements as a row of TD elements
* Prevent a Selenium stale reference error and allow the bulk update metadata test to pass
* Reload create_preassembly_image page until expected text appears

I can confirm the tests now passes in stage.

## Was README.md updated if necessary?

No.

## Are there any configuration changes for shared_configs?

No.