### PR TITLE
the ETD app always operates in the pacific TZ

### DIFF
--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe 'Create a new ETD', type: :feature do
     # fake reader approval
     reader_progress_list_el = all('#progressBoxContent > ol > li')[9]
     expect(reader_progress_list_el).to have_text("Verified by Final Reader\n- Not done")
-    now = Time.now.strftime('%m/%d/%Y %T')
+    now = Time.now.in_time_zone('America/Los_Angeles').strftime('%m/%d/%Y %T')
     resp_body = simulate_registrar_post(reader_approval_xml_from_registrar)
     expect(resp_body).to eq "#{prefixed_druid} updated"
     page.refresh # needed to show updated progress box
@@ -199,7 +199,7 @@ RSpec.describe 'Create a new ETD', type: :feature do
     # fake registrar approval
     registrar_progress_list_el = all('#progressBoxContent > ol > li')[10]
     expect(registrar_progress_list_el).to have_text("Approved by Registrar\n- Not done")
-    now = Time.now.strftime('%m/%d/%Y %T')
+    now = Time.now.in_time_zone('America/Los_Angeles').strftime('%m/%d/%Y %T')
     resp_body = simulate_registrar_post(registrar_approval_xml_from_registrar)
     expect(resp_body).to eq "#{prefixed_druid} updated"
     page.refresh # needed to show updated progress box


### PR DESCRIPTION
## Why was this change made?
This allows the test to better simulate the peoplesoft system, when run in different timezones.

## Was README.md updated if necessary?
n/a

## Are there any configuration changes for shared_configs?
n/a