### PR TITLE
Expand the techMetadata accordion before looking for entries under it

### DIFF
--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe 'SDR deposit', type: :feature do
 
     # Tests existence of technical metadata
     expect(page).to have_content 'Technical metadata'
+    find('#document-techmd-head').click # expand the technical metadata accordion
     file_listing = find_all('#document-techmd-section > ul > li')
-    expect(file_listing.size).to be(2)
+    expect(file_listing.size).to eq 2
   end
 end


### PR DESCRIPTION
## Why was this change made?
It was not finding the tech metadata because it was in a collapsed accordion.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
