### PR TITLE
Bump default wf timeout value

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ etd:
 
 timeouts:
   capybara: 60
-  workflow: 200
+  workflow: 300
   bulk_action: 200
 
 sunet:


### PR DESCRIPTION

## Why was this change made?

I found I needed this bump to help the QA preassembly test pass.

## Was README.md updated if necessary?

N/A

## Are there any configuration changes for shared_configs?

no