### PR TITLE
make pre-assembly image spec less brittle

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
     expect(page).to have_selector('#document-contents-section > .resource-list > li', text: 'Image 1')
     files = all('li.file')
     expect(files.size).to eq 2
-    expect(files.first.text).to eq 'File image.jpg (image/jpeg, 28.9 KB, preserve)'
-    expect(files.last.text).to eq 'File image.jp2 (image/jp2, 64.2 KB, publish/shelve)'
+    expect(files.first.text).to match(%r{(File image.jpg)\s\((image/jpeg, 28.)\d( KB, preserve)\)})
+    expect(files.last.text).to match(%r{(File image.jp2)\s\((image/jp2, 64.)\d( KB, publish/shelve)\)})
 
     # Wait for accessioningWF to finish
     reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)


### PR DESCRIPTION
## Why was this change made?

The preassembly image spec should be ok with image sizes picked up as a faction of a kb different - change the matcher to use a regex to allow for fractions of a kb difference to still pass.

Noticed this test failing from time to time when the image size in contentMetadata was varying by .1 kb in each direction.  See #162 for a bit more detail.

Fixes #162 

## Was README.md updated if necessary?

No

## Are there any configuration changes for shared_configs?

No