### PR TITLE
Add pause before reaccession

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
 
     expect(page).to have_selector('.blacklight-content_type_ssim', text: 'image') # filled in by accessioning
 
+    sleep 10 # let's wait a bit before trying the re-accession to avoid a possible race condition
+
     ### Re-accession
 
     # Get the original version from the page


### PR DESCRIPTION
## Why was this change made?

Fixes #164 (perhaps)

Its possible there is a race condition where we re-accession something in the pre-assembly integration test ... just speculation, though running the test with this fix locally made it work.

## Was README.md updated if necessary?

No

## Are there any configuration changes for shared_configs?

No