### PR TITLE
H2 spec: click on the 'Choose files' button instead of on the drop zone

### DIFF
--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     # Work Deposit view
     expect(page).to have_content('Deposit your content')
     attach_file('spec/fixtures/sul-logo.png') do
-      find('div.dropzone').click
+      find_button('Choose files').click
     end
     expect(page).to have_content('sul-logo.png')
     fill_in 'Title of deposit', with: item_title


### PR DESCRIPTION
## Why was this change made?

so the test in question can upload a file, otherwise, test errors like:
```
  1) Use H2 to create an object is expected to have text "Deposit your content"
     Failure/Error:
       attach_file('spec/fixtures/sul-logo.png') do
         find('div.dropzone').click
       end
     
     ArgumentError:
       Capybara was unable to determine the file input you're attaching to
     # ./spec/features/create_object_h2_spec.rb:43:in `block (2 levels) in <top (required)>'
```

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

n/a