### PR TITLE
Change CI badge to point at paid Travis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/sul-dlss/infrastructure-integration-test.svg?branch=master)](https://travis-ci.org/sul-dlss/infrastructure-integration-test)
+[![Build Status](https://travis-ci.com/sul-dlss/infrastructure-integration-test.svg?branch=master)](https://travis-ci.com/sul-dlss/infrastructure-integration-test)
 
 # SDR Integration Tests
 


### PR DESCRIPTION
## Why was this change made?

This repo does not use .org.

## Was README.md updated if necessary?

Yes

## Are there any configuration changes for shared_configs?

No