### PR TITLE
upgrade sdr-client to address compat issue with rails upgraded sdr-api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ gem 'rubocop', '~> 0.87'
 gem 'rubocop-rspec'
 gem 'rubyXL' # for updating Excel spreadsheets
 gem 'selenium-webdriver'
-gem 'sdr-client', '~> 0.39'
+gem 'sdr-client', '~> 0.40'
 gem 'webdrivers', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.0)
+    activesupport (6.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -37,10 +37,9 @@ GEM
       dry-validation (~> 1.0, >= 1.0.0)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
-    dry-configurable (0.11.6)
+    dry-configurable (0.12.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.4, >= 0.4.7)
-      dry-equalizer (~> 0.2)
+      dry-core (~> 0.5, >= 0.5.0)
     dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
@@ -49,10 +48,9 @@ GEM
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
     dry-initializer (3.0.4)
-    dry-logic (1.0.8)
+    dry-logic (1.1.0)
       concurrent-ruby (~> 1.0)
-      dry-core (~> 0.2)
-      dry-equalizer (~> 0.2)
+      dry-core (~> 0.5, >= 0.5)
     dry-monads (1.3.5)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.4)
@@ -84,19 +82,23 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5, >= 1.5.2)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    i18n (1.8.5)
+    faraday-net_http (1.0.0)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     method_source (1.0.0)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.2)
+    minitest (5.14.3)
     multipart-post (2.1.1)
     nokogiri (1.11.0)
       mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.0-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.0-x86_64-linux)
       racc (~> 1.4)
@@ -113,7 +115,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    psych (3.2.1)
+    psych (3.3.0)
     public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3)
@@ -159,7 +161,7 @@ GEM
       nokogiri (>= 1.10.8)
       rubyzip (>= 1.3.0)
     rubyzip (2.3.0)
-    sdr-client (0.39.0)
+    sdr-client (0.40.1)
       activesupport
       cocina-models (~> 0.44.0)
       dry-monads
@@ -168,7 +170,7 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     thor (1.0.1)
-    tzinfo (2.0.3)
+    tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
     webdrivers (4.4.1)
@@ -181,6 +183,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES
@@ -196,7 +199,7 @@ DEPENDENCIES
   rubocop (~> 0.87)
   rubocop-rspec
   rubyXL
-  sdr-client (~> 0.39)
+  sdr-client (~> 0.40)
   selenium-webdriver
   webdrivers (~> 4.0)
 


### PR DESCRIPTION
## Why was this change made?

`sdr_deposit_spec.rb` was failing because the version of sdr-client in use before this PR had a slight incompatibility with sdr-api after it was upgraded to rails 6.1.

see also https://github.com/sul-dlss/sdr-client/pull/146

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

n/a