### PR TITLE
Find the h2 table with the caption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'activesupport'
 gem 'byebug'
 gem 'capybara'
+gem 'capybara_table'
 gem 'config'
 gem 'faraday' # etds require POST request from registrar
 gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    capybara_table (0.2.1)
+      capybara (>= 2.0)
+      terminal-table
+      xpath (>= 2.1)
     childprocess (3.0.0)
     cocina-models (0.45.0)
       activesupport
@@ -169,6 +173,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -190,6 +196,7 @@ DEPENDENCIES
   activesupport
   byebug
   capybara
+  capybara_table
   config
   faraday
   pry-byebug

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     # deposit an item to a collection.
     reload_page_until_timeout!(text: "Edit #{collection_title}", as_link: true)
     # Deposit an item to the collection
-    find('table', text: collection_title).sibling('button').click
+    find(:table, collection_title).sibling('button').click
 
     # Selects image type
     find('label', text: 'Image').click

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'byebug'
 require 'capybara/rspec'
+require 'capybara_table/rspec'
 require 'csv'
 require 'io/console'
 require 'pry-byebug'


### PR DESCRIPTION

## Why was this change made?

The previous method found any table with the collection title in it. This was a problem because there are now two tables on the page with that text.  This finds just the table that has the collection name as it's caption.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
