### PR TITLE
edit_bulk_tags_spec: improve likelihood of passing

### DIFF
--- a/spec/features/edit_bulk_tags_spec.rb
+++ b/spec/features/edit_bulk_tags_spec.rb
@@ -113,13 +113,13 @@ RSpec.describe 'Use Argo to edit administrative tags in bulk', type: :feature do
     end
 
     visit "#{Settings.argo_url}/view/#{druid_with_added_tag.first}"
-    expect(page).to have_content(added_tag)
+    reload_page_until_timeout!(text: added_tag)
+
+    visit "#{Settings.argo_url}/view/#{druid_with_changed_tag.first}"
+    reload_page_until_timeout!(text: edited_tag)
+    expect(page).not_to have_content(replaced_tag)
 
     visit "#{Settings.argo_url}/view/#{druid_with_removed_tag.first}"
     expect(page).not_to have_content(removed_tag)
-
-    visit "#{Settings.argo_url}/view/#{druid_with_changed_tag.first}"
-    expect(page).to have_content(edited_tag)
-    expect(page).not_to have_content(replaced_tag)
   end
 end


### PR DESCRIPTION
## Why was this change made?

This addresses some intermittent local failures by looking for NEW content first, with page reloads as necessary, and then looking for removed content to be gone.  It was running too quickly and the removed content wasn't gone soon enough.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
