### PR TITLE
fix create_preassembly_image_spec 

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Create and reaccession object via Pre-assembly', type: :feature 
 
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
-    select 'Simple Image', from: 'Content structure'
+    select 'Image', from: 'Content structure'
     fill_in 'Bundle dir', with: preassembly_bundle_dir
 
     click_button 'Submit'


### PR DESCRIPTION
## Why was this change made?

preassembly pulldown value changed with PR sul-dlss/pre-assembly/pull/758 and now our test will work again.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
