### PR TITLE
Fix h2 test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Host *.stanford.edu
     GSSAPIDelegateCredentials yes
 ```
 
+### Problems with Authentication?
+
+If specs fail because they get through authentication without finding the "duo_iframe" "Send Me a Push", add `automatic_authentication: true` to `config/settings.local.yml`.
+
+You may also want to lower the time value of `post_authentication_text_timeout` in `config/settings.local.yml`.
+
 ### Use Chrome Browser
 
 1. `bundle install`

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,3 +18,5 @@ browser:
 
 default_apo: 'druid:qc410yz8746'
 default_collection: 'druid:bc778pm9866'
+
+automatic_authentication: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,3 +20,4 @@ default_apo: 'druid:qc410yz8746'
 default_collection: 'druid:bc778pm9866'
 
 automatic_authentication: false
+post_authentication_text_timeout: 5 # in seconds

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -5,13 +5,12 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
   let(:item_title) { "SUL Logo for #{collection_title}" }
   let(:user_email) { "#{AuthenticationHelpers.username}@stanford.edu" }
 
+  before do
+    authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: 'Create a new collection')
+  end
+
   scenario do
-    visit Settings.h2_url
-    click_link 'Start here'
-    submit_credentials
-
-    click_button 'No' if has_content? 'Continue your deposit'
-
+    click_button 'No' if page.has_content?('Continue your deposit', wait: 100)
     click_link '+ Create a new collection'
 
     # Checks for specific content on create collection view

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
   end
 
   scenario do
-    click_button 'No' if page.has_content?('Continue your deposit', wait: 100)
+    click_button 'No' if page.has_content?('Continue your deposit', wait: Settings.post_authentication_text_timeout)
     click_link '+ Create a new collection'
 
     # Checks for specific content on create collection view

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -15,7 +15,11 @@ module AuthenticationHelpers
     end
   end
 
-  def submit_credentials(expected_text = "")
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/PerceivedComplexity
+  def submit_credentials(expected_text = '')
     self.username ||= username_from_config_or_prompt
     self.password ||= password_from_config_or_prompt
 
@@ -29,11 +33,11 @@ module AuthenticationHelpers
 
     if Settings.automatic_authentication
       # did we already get authenticated?
-      return if page.has_text?(expected_text, wait: Settings.post_authentication_text_timeout) if expected_text.present?
+      return if expected_text.present? && page.has_text?(expected_text, wait: Settings.post_authentication_text_timeout)
 
       # did we already push, but not authenticated?
       begin
-        return if page.has_text?('Pushed a login request to your device', wait: Settings.post_authentication_text_timeout)
+        page.has_text?('Pushed a login request to your device', wait: Settings.post_authentication_text_timeout)
       rescue Capybara::ElementNotFound
         # the app uses an explicit push
         within_frame('duo_iframe') do
@@ -45,8 +49,11 @@ module AuthenticationHelpers
         click_button 'Send Me a Push'
       end
     end
-
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/PerceivedComplexity
 
   def ensure_token
     @@token ||= begin

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -29,11 +29,11 @@ module AuthenticationHelpers
 
     if Settings.automatic_authentication
       # did we already get authenticated?
-      return if page.has_text?(expected_text, wait: 3) if expected_text.present?
+      return if page.has_text?(expected_text, wait: Settings.post_authentication_text_timeout) if expected_text.present?
 
       # did we already push, but not authenticated?
       begin
-        return if page.has_text?('Pushed a login request to your device', wait: 3)
+        return if page.has_text?('Pushed a login request to your device', wait: Settings.post_authentication_text_timeout)
       rescue Capybara::ElementNotFound
         # the app uses an explicit push
         within_frame('duo_iframe') do


### PR DESCRIPTION
## Why was this change made?

These tweaks get the h2 test to work with the changes to authentication from PR #221, and get the hydrus test to work with the indexing changes in PR sul-dlss/dor_indexing_app/pull/580.

I was able to get each of the tests to run green in stage with these changes.

Part of fixing sul-dlss/infrastructure-integration-test/issues/219

FIxes #224 
Fixes #223

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
