### PR TITLE
fix h2 spec; ignore tmp .csv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ spec/examples.txt
 
 # specs create these in the course of operation, but they're
 # ephemeral and shouldn't be committed.
-tmp/manifest.csv
+tmp/*.csv
 downloads
 
 # configs to hold sensitive values

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -76,8 +76,10 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
 
     click_button 'Search'
 
-    # Click on link with the item's title
-    click_link item_title
+    # Click on link with the item's title in the search results
+    within '#documents' do
+      click_link item_title
+    end
 
     # Should be on item view
     find('h1', text: item_title)


### PR DESCRIPTION
## Why was this change made?

H2 spec fails with currently deploying dependency updates due to link ambiguity in Argo...small change to fix this.

Also, update .gitignore so we don't mistakenly commit any manifest .csv files (even the file/media manifests)

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
