### PR TITLE
Only wait one second to see if the password prompt is there.

### DIFF
--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -23,7 +23,7 @@ module AuthenticationHelpers
     self.username ||= username_from_config_or_prompt
     self.password ||= password_from_config_or_prompt
 
-    return unless page.has_content?('SUNet ID')
+    return unless page.has_content?('SUNet ID', wait: 1)
 
     # We're at the Stanford login page
     fill_in 'SUNet ID', with: username


### PR DESCRIPTION
## Why was this change made?

It used to wait 60 seconds every time it checked to see if the login prompt was visible. There's no call for waiting that long.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
