### PR TITLE
Check that wf created for create_object_no_files spec.

### DIFF
--- a/spec/features/create_object_no_files_spec.rb
+++ b/spec/features/create_object_no_files_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
     find_link('Add workflow').click
     select 'accessionWF', from: 'wf'
     find_button('Add').click
+    expect(page).to have_text('Added accessionWF')
 
     # wait for accessioningWF to finish
     reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)


### PR DESCRIPTION
## Why was this change made?
In some runs, the workflows was not being created. This will catch that problem.

## Was README.md updated if necessary?
NA

## Are there any configuration changes for shared_configs?
NA