### PR TITLE
Tweak to bulk_update_metadata spec to allow for slow upload.

### DIFF
--- a/spec/features/bulk_update_metadata_spec.rb
+++ b/spec/features/bulk_update_metadata_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
     choose 'Spreadsheet input; load into objects'
     fill_in '3. Note', with: note
     click_button 'Submit'
+    expect(page).to have_content('Bulk processing started')
 
     reload_page_until_timeout!(text: note)
 


### PR DESCRIPTION
## Why was this change made?
Test was failing due to slow upload.

Why is the upload slow? No idea.


## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
