### PR TITLE
Update selectors for new embargo modal

### DIFF
--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -238,13 +238,13 @@ RSpec.describe 'Create a new ETD', type: :feature do
       expect(page).not_to have_content('up to 7 days')
     end
 
-    # update embargo
+    # Manage embargo
     new_embargo_date = Date.today + 3
     visit "#{Settings.argo_url}/view/#{prefixed_druid}"
-    find_link('Update embargo').click
+    find_link('Manage embargo').click
     within '#blacklight-modal' do
-      fill_in('embargo_date', with: new_embargo_date.strftime('%F'))
-      click_button 'Update Embargo'
+      fill_in('Enter the date when this embargo ends', with: new_embargo_date.strftime('%F'))
+      click_button 'Save'
     end
     reload_page_until_timeout!(text: "This item is embargoed until #{new_embargo_date.strftime('%F').tr('-', '.')}",
                                with_reindex: true)

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -99,10 +99,10 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     # change embargo date
     new_embargo_date = Date.today + 3
     visit "#{Settings.argo_url}/view/#{bare_druid}"
-    find_link('Update embargo').click
+    find_link('Manage embargo').click
     within '#blacklight-modal' do
-      fill_in('embargo_date', with: new_embargo_date.strftime('%F'))
-      click_button 'Update Embargo'
+      fill_in('Enter the date when this embargo ends', with: new_embargo_date.strftime('%F'))
+      click_button 'Save'
     end
     reload_page_until_timeout!(text: "This item is embargoed until #{new_embargo_date.strftime('%F').tr('-', '.')}",
                                with_reindex: true)

--- a/spec/features/deposit_via_hydrus_spec.rb
+++ b/spec/features/deposit_via_hydrus_spec.rb
@@ -107,10 +107,10 @@ RSpec.describe 'Use Hydrus to deposit an item', type: :feature do
     # change embargo date
     new_embargo_date = Date.today + 3
     visit "#{Settings.argo_url}/view/#{bare_druid}"
-    find_link('Update embargo').click
+    find_link('Manage embargo').click
     within '#blacklight-modal' do
-      fill_in('embargo_date', with: new_embargo_date.strftime('%F'))
-      click_button 'Update Embargo'
+      fill_in('Enter the date when this embargo ends', with: new_embargo_date.strftime('%F'))
+      click_button 'Save'
     end
     reload_page_until_timeout!(text: "This item is embargoed until #{new_embargo_date.strftime('%F').tr('-', '.')}",
                                with_reindex: true)


### PR DESCRIPTION
## Why was this change made?

After https://github.com/sul-dlss/argo/pull/2728 is merged, the text and selector of the embargo update form is slightly different. 

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
