### PR TITLE
Search more like human user

### DIFF
--- a/spec/features/access_indexing_spec.rb
+++ b/spec/features/access_indexing_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe 'Argo rights changes result in correct Access Rights facet value'
 end
 
 def find_access_rights_single_facet_value(druid, facet_value)
-  visit "#{Settings.argo_url}/catalog?search_field=text&q=#{druid}"
+  fill_in 'Search...', with: druid
+  click_button 'Search'
   click_button('Access Rights')
   within '#facet-rights_descriptions_ssim ul.facet-values' do
     within 'li' do

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -232,7 +232,8 @@ RSpec.describe 'Create a new ETD', type: :feature do
 
     # test Embargo UI and indexing before an item is fully accessioned
     # check Argo facet field with 6 month embargo
-    visit "#{Settings.argo_url}/catalog?search_field=text&q=#{prefixed_druid}"
+    fill_in 'Search...', with: prefixed_druid
+    click_button 'Search'
     click_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do
       expect(page).not_to have_content('up to 7 days')
@@ -250,8 +251,8 @@ RSpec.describe 'Create a new ETD', type: :feature do
                                with_reindex: true)
 
     # check Argo facet field with 3 day embargo
-    sleep 1 # Without this, skips the visit below. I have no idea why ...
-    visit "#{Settings.argo_url}/catalog?search_field=text&q=#{prefixed_druid}"
+    fill_in 'Search...', with: prefixed_druid
+    click_button 'Search'
     click_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do
       find_link('up to 7 days')

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
                                with_reindex: true)
 
     # check Argo facet field with 3 day embargo
-    visit "#{Settings.argo_url}/catalog?search_field=text&q=#{bare_druid}"
+    fill_in 'Search...', with: bare_druid
+    click_button 'Search'
     reload_page_until_timeout!(text: 'Embargo Release Date')
     click_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do

--- a/spec/features/deposit_via_hydrus_spec.rb
+++ b/spec/features/deposit_via_hydrus_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe 'Use Hydrus to deposit an item', type: :feature do
     expect(page).to have_content "This item is embargoed until #{embargo_date.strftime('%F').tr('-', '.')}"
 
     # check Argo facet field (indexed embargo date) with 6 month embargo
-    visit "#{Settings.argo_url}/catalog?search_field=text&q=#{item_druid}"
+    fill_in 'Search...', with: item_druid
+    click_button 'Search'
     reload_page_until_timeout!(text: 'Embargo Release Date')
     click_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do
@@ -116,7 +117,8 @@ RSpec.describe 'Use Hydrus to deposit an item', type: :feature do
                                with_reindex: true)
 
     # check Argo facet field (indexed embargo date) with 3 day embargo
-    visit "#{Settings.argo_url}/catalog?search_field=text&q=#{bare_druid}"
+    fill_in 'Search...', with: bare_druid
+    click_button 'Search'
     reload_page_until_timeout!(text: 'Embargo Release Date')
     click_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do


### PR DESCRIPTION
## Why was this change made?

_TLDR_:  "making the test use the search box was more reliable for me than having the test construct the search URL and visit it directly"

less handwavily...

I found that with the pattern of directly visiting the search URL, sometimes the browser running the specs would get hung up on the page it was navigating away from.  This was especially true when I was running `deposit_via_hydrus_spec.rb` and `create_object_h2_spec.rb` yesterday (as part of running the test suite for weekly dependency updates before deploying to prod).

I tested manually in my browser, and using the search field as this PR does leads to the same URL that the tests were constructing explicitly before this PR's change.

My hunch is that Capybara and the browser instance it uses get tripped up sometimes when a URL is visited, and it attempts to immediately start refreshing the page before it's fully loaded.  I've certainly run into that many times over the years with regular totally manual browser usage, and it fits with the behavior that I observed while the tests were running (i.e. tests refreshing the detail page forever, when Capybara/FF should've already moved onto the search results page, which has the expected content if one navigates to it in a separate browser and actually waits for it to load).  I suspect that Capybara is better about waiting for the page to load if the user navigates by clicking around and submitting forms than if the user visits an address directly.

Though the issue was most acute for me with `deposit_via_hydrus_spec.rb`, I did run into it a couple times with `create_object_h2_spec.rb`.  Since this approach should work just as well as the one it's replacing, if not better, and since it's slightly more realistic, I went ahead and made the change everywhere, to keep things consistent.  I kept the `create_object_h2_spec.rb` change and the other non-`deposit_via_hydrus_spec.rb` changes in separate commits, so it'd be easy to lop them off if others would prefer only changing `deposit_via_hydrus_spec.rb`.

I ran the suite this morning, with these changes in place, and everything passed against stage.  `deposit_via_hydrus_spec.rb` was certainly more reliable for me than it had been yesterday.

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

n/a