### PR TITLE
Test for text before reindexing

### DIFF
--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -4,16 +4,16 @@ module PageHelpers
   def reload_page_until_timeout!(text:, as_link: false, with_reindex: false)
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
-        if with_reindex
-          click_link 'Reindex'
-        else
-          page.driver.browser.navigate.refresh
-        end
-
         if as_link
           break if page.has_link?(text, wait: 1)
         else
           break if page.has_text?(text, wait: 1)
+        end
+
+        if with_reindex
+          click_link 'Reindex'
+        else
+          page.driver.browser.navigate.refresh
         end
       end
     end


### PR DESCRIPTION


## Why was this change made?
There's no sense in running the reindex if the text already exists on the page

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
