### PR TITLE
check event service to confirm preservation replicated new versions to all cloud endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'capybara'
 gem 'capybara_table'
 gem 'config'
 gem 'dor-services-client', '~> 6.34'
+gem 'druid-tools' # for constructing druid tree strings easily
 gem 'faraday' # etds require POST request from registrar
 gem 'pry-byebug'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ DEPENDENCIES
   capybara_table
   config
   dor-services-client (~> 6.34)
+  druid-tools
   faraday
   pry-byebug
   rake

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,10 @@ timeouts:
   capybara: 60
   workflow: 300
   bulk_action: 200
+  events:
+    poll_for: 240
+    poll_interval: 2
+
 
 browser:
   driver: firefox

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,7 @@ RSpec.configure do |config|
   config.include AuthenticationHelpers
   config.include DepositHelpers
   config.include DownloadHelpers
+  config.include EventHelpers
   config.include PageHelpers
   config.include PublicXmlHelpers
   config.include XlsxHelpers

--- a/spec/support/event_helpers.rb
+++ b/spec/support/event_helpers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EventHelpers
+  # pass in a block that returns true if the event list has the desired event(s)
+  def poll_for_matching_events!(prefixed_druid)
+    Dor::Services::Client.configure(url: Settings.dor_services.url, token: Settings.dor_services.token)
+    object_client = Dor::Services::Client.object(prefixed_druid)
+
+    Timeout.timeout(Settings.timeouts.events.poll_for) do
+      loop do
+        events = object_client.events.list
+        break if yield(events)
+
+        sleep Settings.timeouts.events.poll_interval
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 module PageHelpers
-  def reload_page_until_timeout!(text:, as_link: false, with_reindex: false)
+  def reload_page_until_timeout!(text:, as_link: false, with_reindex: false, with_events_expanded: false)
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
+        if with_events_expanded
+          find('#document-events-head').click # expand the Events section
+        end
+
         if as_link
           break if page.has_link?(text, wait: 1)
         else


### PR DESCRIPTION
## Why was this change made?

so that infra integration test suite can confirm that preservation and replication are working, since it's already implicitly exercised by accessioning.

closes #249

also, adds a (hopefully) generally useful helper method and pattern for querying the event service.

~~leaving in draft, as accessioning was wedged on stage when i tried to test last night (`provenanceMetadata` wasn't getting created, but i did test just this change by commenting out all of this class except the new event service check, and then hardcoding a known druid and version from stage -- obviously not a realistic enough test to merge this change).~~

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

nope