### PR TITLE
Improve 2 tests, clarify settings needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you are experiencing timeout errors when running tests, you may override the 
 
 ### Set Dor-Services-App Tokens
 
-Some integration tests use the `dor-services-client` to interact with the `dor-services-app`. In order to successfully use the dor-services-app API, you must first have a token set. (To generate dor-services-app tokens, see the [dor-services-app README](https://github.com/sul-dlss/dor-services-app#authentication).) Note that you'll need to do this for each environment (currently: stage and QA). Place the value in `config/settings/{ENV}.local.yml`. See `config/settings.yml` for the expected YAML syntax.
+Some integration tests use the `dor-services-client` to interact with the `dor-services-app`, others directly (or indirectly) use the `dor-services-app`.  In order to successfully use the dor-services-app API, you must first have a token set. (To generate dor-services-app tokens, see the [dor-services-app README](https://github.com/sul-dlss/dor-services-app#authentication).) Note that you'll need to do this for each environment (currently: staging and qa). Place the value in `config/settings/{ENV}.local.yml`. See `config/settings.yml` for the expected YAML syntax.
 
 ### Set SUNet Credentials
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,13 @@ etd:
   username: ~
   password: ~
 
+# for calls to dor-services-app (not using dor-services-client directly)
+# note that this token is the same as below ...
+dor_services_app:
+  token: ~
+
+# for direct use of dor-services-client (e.g. to get public_xml from dor-services-app)
+# note that this token is the same as above ...
 dor_services:
   token: ~
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,10 +1,11 @@
 argo_url: 'https://argo-qa.stanford.edu'
+dor_services:
+  url: 'https://dor-services-qa.stanford.edu'
 etd_url: 'https://etd-qa.stanford.edu'
 h2_url: 'https://sul-h2-qa.stanford.edu'
+h2_purl_url: 'https://purl-stage.stanford.edu' # from shared_configs for sul-h2-qa
 hydrus_url: 'https://sdr-qa.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-qa'
 preassembly_url: 'https://sul-preassembly-qa.stanford.edu'
 sdrapi_url: 'https://sdr-api-qa.stanford.edu'
-dor_services:
-  url: 'https://dor-services-qa.stanford.edu'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,10 +1,11 @@
 argo_url: 'https://argo-stage.stanford.edu'
+dor_services:
+  url: 'https://dor-services-stage.stanford.edu'
 etd_url: 'https://etd-stage.stanford.edu'
 h2_url: 'https://sul-h2-stage.stanford.edu'
+h2_purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
 hydrus_url: 'https://sdr-test.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-stage'
 preassembly_url: 'https://sul-preassembly-stage.stanford.edu'
 sdrapi_url: 'https://sdr-api-stage.stanford.edu'
-dor_services:
-  url: 'https://dor-services-stage.stanford.edu'

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     # Checks if title is on resulting display
     expect(page).to have_content(item_title)
     # This happens asynchronously, it might take a bit
-    expect(page).to have_content('https://sul-purl-stage.stanford.edu')
+    expect(page).to have_content(Settings.h2_purl_url)
 
     # Opens Argo and searches on title
     visit Settings.argo_url

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -12,6 +12,8 @@ module PageHelpers
 
         if with_reindex
           click_link 'Reindex'
+          # ensure we see this message before we do the next thing
+          expect(page).to have_text('Successfully updated index for')
         else
           page.driver.browser.navigate.refresh
         end


### PR DESCRIPTION
## Why was this change made?


52ffab5  - clarify the README and the settings.yml files re: token needed for both dor-services-app and dor-services-client
2d180df - fixes a race condition in the create_object_no_files test for less flappiness (yay!)
4133a17 - h2 test uses settings h2_purl_url so it works for both qa and stage.

## Was README.md updated if necessary?

yes, it was.

## Are there any configuration changes for shared_configs?
