### PR TITLE
fixes h2 integration test

### DIFF
--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     reload_page_until_timeout!(text: "Edit #{collection_title}", as_link: true)
 
     # Deposit an item to the collection
-    find(:table, collection_title).sibling('turbo-frame').first(:button).click
+    click_button '+ Deposit to this collection'
 
     # Selects image type
     find('label', text: 'Image').click


### PR DESCRIPTION
## Why was this change made?

The H2 integration test was failing due to a bad selector.  This fixes it.

Note: this test still fails in qa since there is no purl-qa.stanford.edu

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
