### PR TITLE
bump cocina-models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       terminal-table
       xpath (>= 2.1)
     childprocess (3.0.0)
-    cocina-models (0.59.0)
+    cocina-models (0.59.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -58,7 +58,7 @@ GEM
     dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.5.0)
+    dry-core (0.6.0)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)


### PR DESCRIPTION
## Why was this change made?

We need cocina-models in the integration tests to match on our services for all test to pass.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
