### PR TITLE
correct settings/qa.yml for h2_purl_url

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -3,7 +3,8 @@ dor_services:
   url: 'https://dor-services-qa.stanford.edu'
 etd_url: 'https://etd-qa.stanford.edu'
 h2_url: 'https://sul-h2-qa.stanford.edu'
-h2_purl_url: 'https://purl-stage.stanford.edu' # from shared_configs for sul-h2-qa
+# for h2_purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
+h2_purl_url: 'https://sul-purl-stage.stanford.edu'
 hydrus_url: 'https://sdr-qa.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-qa'


### PR DESCRIPTION
## Why was this change made?

So h2 test can pass in qa environment. 

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

n/a