### PR TITLE
http:// has been determined to be the canonical protocol for PURL

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -4,7 +4,7 @@ dor_services:
 etd_url: 'https://etd-qa.stanford.edu'
 h2_url: 'https://sul-h2-qa.stanford.edu'
 # for h2_purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
-h2_purl_url: 'https://sul-purl-stage.stanford.edu'
+h2_purl_url: 'http://sul-purl-stage.stanford.edu'
 hydrus_url: 'https://sdr-qa.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-qa'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -3,7 +3,7 @@ dor_services:
   url: 'https://dor-services-stage.stanford.edu'
 etd_url: 'https://etd-stage.stanford.edu'
 h2_url: 'https://sul-h2-stage.stanford.edu'
-h2_purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
+h2_purl_url: 'http://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
 hydrus_url: 'https://sdr-test.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-stage'


### PR DESCRIPTION

## Why was this change made?

see discussion in slack, #dlss-infrastructure, week of 2021-06-21 and -06-28

## Was README.md updated if necessary?

n/a

## Are there any configuration changes for shared_configs?

nope, just configs in this app