### PR TITLE
change purl url and fix terms checkbox

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -4,7 +4,7 @@ dor_services:
 etd_url: 'https://etd-qa.stanford.edu'
 h2_url: 'https://sul-h2-qa.stanford.edu'
 # for h2_purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
-h2_purl_url: 'http://sul-purl-stage.stanford.edu'
+h2_purl_url: 'https://sul-purl-stage.stanford.edu'
 hydrus_url: 'https://sdr-qa.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-qa'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -3,7 +3,7 @@ dor_services:
   url: 'https://dor-services-stage.stanford.edu'
 etd_url: 'https://etd-stage.stanford.edu'
 h2_url: 'https://sul-h2-stage.stanford.edu'
-h2_purl_url: 'http://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
+h2_purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
 hydrus_url: 'https://sdr-test.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-stage'

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     fill_in 'Abstract', with: "An abstract for #{collection_title} logo"
     fill_in 'Keyword', with: 'Integration test'
 
-    check('I agree to the SDR Terms of Deposit')
+    # if you have previously agree to the terms within the last year, there will be no checkbox
+    check('I agree to the SDR Terms of Deposit') if page.has_css?('#work_agree_to_terms', wait: 0)
 
     find_button('Deposit').click
 


### PR DESCRIPTION
## Why was this change made?

1. PURL now uses https URLs
2. The terms checkbox for H2 is now conditional and will  not always appear - verify it exists before trying to check the box. 

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
