### PR TITLE
when re-indexing, still force a page refresh

### DIFF
--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -22,9 +22,8 @@ module PageHelpers
           click_link 'Reindex'
           # ensure we see this message before we do the next thing
           expect(page).to have_text('Successfully updated index for')
-        else
-          page.driver.browser.navigate.refresh
         end
+        page.driver.browser.navigate.refresh
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

The `spec/features/sdr_deposit_spec.rb` started failing because the page in Argo never shows the object as completed accessioning, even though it had (as could be verified in another browser window).  This just forces the page to refresh even if a re-index was requested.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
