### PR TITLE
fix broken create_object_no_files_spec

### DIFF
--- a/spec/features/create_object_no_files_spec.rb
+++ b/spec/features/create_object_no_files_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
       click_button 'Close Version'
     end
     expect(page).to have_text('closing version for integration testing')
+    page.refresh # solves problem of close version modal re-appearing
 
     # wait for accessioningWF to finish
     reload_page_until_timeout!(text: 'v2 Accessioned', with_reindex: true)


### PR DESCRIPTION
## Why was this change made?

"close version" modal was reappearing when it shouldn't (using firefox).  There may be a better solution via the Argo code, but this gets the tests to pass.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
