### PR TITLE
Fix broken create_etd_spec

### DIFF
--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -247,6 +247,7 @@ RSpec.describe 'Create a new ETD', type: :feature do
       fill_in('Enter the date when this embargo ends', with: new_embargo_date.strftime('%F'))
       click_button 'Save'
     end
+    page.refresh # solves problem of update embargo modal re-appearing
     reload_page_until_timeout!(text: "This item is embargoed until #{new_embargo_date.strftime('%F').tr('-', '.')}",
                                with_reindex: true)
 

--- a/spec/features/create_etd_spec.rb
+++ b/spec/features/create_etd_spec.rb
@@ -263,7 +263,7 @@ end
 
 def simulate_registrar_post(xml)
   conn = Faraday.new(url: "#{Settings.etd_url}/etds")
-  conn.basic_auth(Settings.etd.username, Settings.etd.password)
+  conn.request(:basic_auth, Settings.etd.username, Settings.etd.password)
   resp = conn.post do |req|
     req.options.timeout = 10
     req.options.open_timeout = 10


### PR DESCRIPTION
## Why was this change made?

- Embargo date modal was re-appearing when it shouldn't (using firefox).  There may be a better solution via the Argo code, but this gets the tests to pass.
- avoid a ton of Faraday warnings by using their new syntax for authentication.

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
