### PR TITLE
README: improve documentation on authentication configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,19 @@ The tests depend on having Firefox (default) or Chrome downloaded.
 1. `bundle install`
 1. `bundle exec rake webdrivers:geckodriver:update`
 
-See the `Configuration` section below for instructions on using Chrome and on tweaking default browser settings.
+See the `Authentication Configuration` section below for
+- authentication token instructions (dor_services_app, dor_services, etd)
+- etd username instructions
+
+See the `Other Configuration` section below for
+- instructions on using Chrome
+- tweaking default selenium browser settings.
 
 ## Prerequisites
 
 1. Connect to Stanford VPN (full-tunnel or split-tunnel)
 1. Ensure you have a valid, non-expired Kerberos ticket (use `klist` to verify, or run `kinit` to refresh)
-
-See the `Configuration` section below for instructions on allowing SSH credential delegation.
+1. See the `Authentication Configuration` section below for instructions on setting up necessary credentials.
 
 ## Run Tests
 
@@ -32,7 +37,7 @@ To test in the SDR QA environment, run tests with the `SDR_ENV` environment vari
 SDR_ENV=qa bundle exec rspec
 ```
 
-No matter which environment you run tests in, you may be prompted to type in your Stanford credentials and will then need to approve a multi-factor authentication push. If you tire of typing in your credentials, see the `Configuration` section below for help securely storing them.
+No matter which environment you run tests in, you may be prompted to type in your Stanford credentials and will then need to approve a multi-factor authentication push. If you tire of typing in your credentials, see the `Other Configuration` section below for help securely storing them.
 
 ## Add New Tests
 
@@ -41,7 +46,7 @@ Please use the integration-testing APO and collection when feasible:
 * APO: druid:qc410yz8746 (available as `Settings.default_apo`)
 * Collection: druid:bc778pm9866 (available as `Settings.default_collection`)
 
-## Configuration
+## Authentication Configuration
 
 ### Allow Credential Delegation
 
@@ -53,11 +58,39 @@ Host *.stanford.edu
     GSSAPIDelegateCredentials yes
 ```
 
+### Set Dor-Services-App and Dor-Services Tokens
+
+Some integration tests use the `dor-services-client` to interact with the `dor-services-app`, others directly (or indirectly) use the `dor-services-app`.  In order to successfully use the dor-services-app API, you must first have a token set. (To generate dor-services-app tokens, see the [dor-services-app README](https://github.com/sul-dlss/dor-services-app#authentication).)
+
+Place the value in `config/settings/{ENV}.local.yml`. See `config/settings.yml` for the expected YAML syntax. Note that you'll need to do this for each environment (currently: staging and qa), and you'll need top level keys of *both* `dor-services-app` and `dor-services` (same token). See `settings.yml` for explanation.
+
+### Set ETD Credentials
+
+In order to run `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application. This is environment-specific.
+
+#### Staging Environment
+
+For the staging environment, copy `config/settings.yml` to `config/settings/staging.local.yml` and set the ETD username and password to the [values expected in our staging environment](https://github.com/sul-dlss/shared_configs/blob/a90c636b968a1ede4886a61dadc799dd5d162fe1/config/settings/production.yml#L34-L35).
+
+**NOTE**: `config/settings/staging.local.yml` is ignored by git and should remain so. Please do not add this file to version control.
+
+#### QA Environment
+
+For the QA environment, copy `config/settings.yml` to `config/settings/qa.local.yml` and set the ETD username and password to the [values expected in our QA environment](https://github.com/sul-dlss/shared_configs/blob/59ead7acbdf351930ad45922fd44e0f45810bf37/config/settings/production.yml#L16-L17).
+
+**NOTE**: `config/settings/qa.local.yml` is ignored by git and should remain so. Please do not add this file to version control.
+
 ### Problems with Authentication?
 
 If specs fail because they get through authentication without finding the "duo_iframe" "Send Me a Push", add `automatic_authentication: true` to `config/settings.local.yml`.
 
 You may also want to lower the time value of `post_authentication_text_timeout` in `config/settings.local.yml`.
+
+## Other Configuration
+
+### Set SUNet Credentials
+
+If you tire of typing in your SUNet credentials over and over, you may add them to `config/settings.local.yml` (ignored by git). Copy the dummy values from `config/settings.yml` to get started. Do *not* add this file to version control, if you do this!
 
 ### Use Chrome Browser
 
@@ -72,27 +105,3 @@ If you find you need to modify the default window size for either browser---*e.g
 ### Increase Timeout Values
 
 If you are experiencing timeout errors when running tests, you may override the default timeout values by adding `timeouts.capybara`, `timeouts.bulk_action`, and/or `timeouts.workflow` in `config/settings.local.yml` depending on where you see timeouts.
-
-### Set Dor-Services-App Tokens
-
-Some integration tests use the `dor-services-client` to interact with the `dor-services-app`, others directly (or indirectly) use the `dor-services-app`.  In order to successfully use the dor-services-app API, you must first have a token set. (To generate dor-services-app tokens, see the [dor-services-app README](https://github.com/sul-dlss/dor-services-app#authentication).) Note that you'll need to do this for each environment (currently: staging and qa). Place the value in `config/settings/{ENV}.local.yml`. See `config/settings.yml` for the expected YAML syntax.
-
-### Set SUNet Credentials
-
-If you tire of typing in your SUNet credentials over and over, you may add them to `config/settings.local.yml` (ignored by git). Copy the dummy values from `config/settings.yml` to get started. Do *not* add this file to version control, if you do this!
-
-### Set ETD Credentials
-
-In order to run the tests in `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application. This is environment-specific.
-
-#### Staging Environment
-
-For the staging environment, copy `config/settings.yml` to `config/settings/staging.local.yml` and set the ETD username and password to the [values expected in our staging environment](https://github.com/sul-dlss/shared_configs/blob/a90c636b968a1ede4886a61dadc799dd5d162fe1/config/settings/production.yml#L34-L35).
-
-**NOTE**: `config/settings/staging.local.yml` is ignored by git and should remain so. Please do not add this file to version control.
-
-#### QA Environment
-
-For the QA environment, copy `config/settings.yml` to `config/settings/qa.local.yml` and set the ETD username and password to the [values expected in our QA environment](https://github.com/sul-dlss/shared_configs/blob/59ead7acbdf351930ad45922fd44e0f45810bf37/config/settings/production.yml#L16-L17).
-
-**NOTE**: `config/settings/qa.local.yml` is ignored by git and should remain so. Please do not add this file to version control.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ The tests depend on having Firefox (default) or Chrome downloaded.
 1. `bundle install`
 1. `bundle exec rake webdrivers:geckodriver:update`
 
-See the `Authentication Configuration` section below for
-- authentication token instructions (dor_services_app, dor_services, etd)
-- etd username instructions
-
 See the `Other Configuration` section below for
 - instructions on using Chrome
 - tweaking default selenium browser settings.
@@ -23,7 +19,9 @@ See the `Other Configuration` section below for
 
 1. Connect to Stanford VPN (full-tunnel or split-tunnel)
 1. Ensure you have a valid, non-expired Kerberos ticket (use `klist` to verify, or run `kinit` to refresh)
-1. See the `Authentication Configuration` section below for instructions on setting up necessary credentials.
+1. See the `Authentication Configuration` section below to set up necessary credentials:
+- dor_services_app credentials
+- etd credentials
 
 ## Run Tests
 
@@ -55,30 +53,28 @@ Configure your SSH client to allow delegation of Kerberos credentials (required 
 ```
 # Add to appropriate place, such as:
 Host *.stanford.edu
-    GSSAPIDelegateCredentials yes
+  GSSAPIDelegateCredentials yes
 ```
 
-### Set Dor-Services-App and Dor-Services Tokens
+### Staging Environment
 
-Some integration tests use the `dor-services-client` to interact with the `dor-services-app`, others directly (or indirectly) use the `dor-services-app`.  In order to successfully use the dor-services-app API, you must first have a token set. (To generate dor-services-app tokens, see the [dor-services-app README](https://github.com/sul-dlss/dor-services-app#authentication).)
-
-Place the value in `config/settings/{ENV}.local.yml`. See `config/settings.yml` for the expected YAML syntax. Note that you'll need to do this for each environment (currently: staging and qa), and you'll need top level keys of *both* `dor-services-app` and `dor-services` (same token). See `settings.yml` for explanation.
-
-### Set ETD Credentials
-
-In order to run `spec/features/create_etd_spec.rb`, you will need to specify credentials required to authenticate connections to the ETD application. This is environment-specific.
-
-#### Staging Environment
-
-For the staging environment, copy `config/settings.yml` to `config/settings/staging.local.yml` and set the ETD username and password to the [values expected in our staging environment](https://github.com/sul-dlss/shared_configs/blob/a90c636b968a1ede4886a61dadc799dd5d162fe1/config/settings/production.yml#L34-L35).
+For the staging environment, copy `config/settings.yml` to `config/settings/staging.local.yml`.  You will be adding staging environment specific settings here.
 
 **NOTE**: `config/settings/staging.local.yml` is ignored by git and should remain so. Please do not add this file to version control.
 
-#### QA Environment
+### QA Environment
 
-For the QA environment, copy `config/settings.yml` to `config/settings/qa.local.yml` and set the ETD username and password to the [values expected in our QA environment](https://github.com/sul-dlss/shared_configs/blob/59ead7acbdf351930ad45922fd44e0f45810bf37/config/settings/production.yml#L16-L17).
+For the QA environment, copy `config/settings.yml` to `config/settings/qa.local.yml`.  You will be adding staging environment specific settings here.
 
 **NOTE**: `config/settings/qa.local.yml` is ignored by git and should remain so. Please do not add this file to version control.
+
+### Set Dor-Services-App Credentials
+
+Some integration tests use the `dor-services-client` to interact with the `dor-services-app`. In order to successfully use the dor-services-client, you must first have a token. To generate dor-services-app tokens, see the [dor-services-app README](https://github.com/sul-dlss/dor-services-app#authentication). You'll need to generate separate tokens for each dor-services-app environment (stage, qa), and add them to `config/settings/staging.local.yml` and `config/settings/qa.local.yml`.  See `config/settings.yml` for the expected YAML syntax.
+
+### Set ETD Credentials
+
+In order to run `spec/features/create_etd_spec.rb`, you will the ETD application's backdoor username and password for HTTP POST requests.  You'll need to get these valuse from shared_configs for the etd stage and qa branches, and add them to `config/settings/staging.local.yml` and `config/settings/qa.local.yml`.  See `config/settings.yml` for the expected YAML syntax.
 
 ### Problems with Authentication?
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,6 @@ timeouts:
     poll_for: 240
     poll_interval: 2
 
-
 browser:
   driver: firefox
   height: 900
@@ -22,13 +21,8 @@ etd:
   username: ~
   password: ~
 
-# for calls to dor-services-app (not using dor-services-client directly)
-# note that this token is the same as below ...
-dor_services_app:
-  token: ~
-
-# for direct use of dor-services-client (e.g. to get public_xml from dor-services-app)
-# note that this token is the same as above ...
+# for dor-services-client (e.g. to get public_xml from dor-services-app)
+# See README for instructions
 dor_services:
   token: ~
 


### PR DESCRIPTION
## Why was this change made?

- improve documentation on authentication configuration 
- reorder to have required configuration information before optional information

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
