### PR TITLE
Rename config variable to purl_url

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -3,8 +3,8 @@ dor_services:
   url: 'https://dor-services-qa.stanford.edu'
 etd_url: 'https://etd-qa.stanford.edu'
 h2_url: 'https://sul-h2-qa.stanford.edu'
-# for h2_purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
-h2_purl_url: 'https://sul-purl-stage.stanford.edu'
+# for purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
+purl_url: 'https://sul-purl-stage.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-qa'
 preassembly_url: 'https://sul-preassembly-qa.stanford.edu'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -3,7 +3,7 @@ dor_services:
   url: 'https://dor-services-stage.stanford.edu'
 etd_url: 'https://etd-stage.stanford.edu'
 h2_url: 'https://sul-h2-stage.stanford.edu'
-h2_purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
+purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-stage'
 preassembly_url: 'https://sul-preassembly-stage.stanford.edu'

--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
 
     # Checks if title is on resulting display
     expect(page).to have_content(item_title)
-    expect(page).to have_content(Settings.h2_purl_url) # async - it might take a bit
+    expect(page).to have_content(Settings.purl_url) # async - it might take a bit
 
     # Opens Argo and searches on title
     visit Settings.argo_url


### PR DESCRIPTION
## Why was this change made?

The name `h2_purl_url` threw me a bit. I can see that we only check the purl URL in the H2 test, but the name suggests that H2 has its own purl service to me. This commit changes that name to `purl_url`. FWIW, `purl_url` is a name we use elsewhere, like `shared_configs`, and I can't find any other usage of `h2_purl_url`.

## Was README.md updated if necessary?

Nope.

## Are there any configuration changes for shared_configs?

None for shared_configs, no.