### PR TITLE
Fix kwargs error.

### DIFF
--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -2,7 +2,7 @@
 
 module DepositHelpers
   def deposit(**kwargs)
-    job_id = SdrClient::Deposit.run(kwargs)
+    job_id = SdrClient::Deposit.run(**kwargs)
 
     # Wait for the deposit to be complete.
     object_druid = nil


### PR DESCRIPTION
## Why was this change made?

```
$ bundle exec rspec ./spec/features/sdr_deposit_spec.rb
Run options: exclude {:indexing=>true}

Randomized with seed 17224

SDR deposit
  deposits objects (FAILED - 1)

Failures:

  1) SDR deposit deposits objects
     Failure/Error: job_id = SdrClient::Deposit.run(kwargs)

     ArgumentError:
       wrong number of arguments (given 1, expected 0; required keywords: apo, source_id, url)
     # ./spec/support/deposit_helpers.rb:5:in `deposit'
     # ./spec/features/sdr_deposit_spec.rb:14:in `block (2 levels) in <top (required)>'

Finished in 14.93 seconds (files took 2.6 seconds to load)
1 example, 1 failure
```


## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
