### PR TITLE
Update Travis Ruby version to 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ notifications:
   email: false
 
 rvm:
-  - 2.7
+  - 3.0


### PR DESCRIPTION
## Why was this change made?
Put Travis's ruby version in sync with other projects, updating from 2.7 to 3.0. Not sure how to test this, although I know people have run infrastructure-integration tests with that Ruby 3.0. 

## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
No
