### PR TITLE
[HOLD?] Preassembly with every access

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,8 @@ Metrics/BlockLength:
     - it
     - context
     - scenario
+  Exclude:
+    - 'spec/features/create_preassembly_image_spec.rb'
 
 Metrics/MethodLength:
   Max: 20

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -16,7 +16,7 @@ module PageHelpers
 
         # Check for workflow errors and bail out early. There is no recovering
         # from a workflow error. This selector is found on the Argo item page.
-        expect(page).not_to have_css('.blacklight-wf_error_ssim', wait: 0)
+        expect(page).not_to have_css('.alert-danger', wait: 0)
 
         if with_reindex
           click_link 'Reindex'


### PR DESCRIPTION
## Why was this change made?

This tests preassembly accessioning with every access.  This was able to detect https://github.com/sul-dlss/common-accessioning/issues/843 in a way that no single suite can with the tools we have today (see https://github.com/sul-dlss/cocina-models/issues/313)

Unfortunately, this adds about 20min to the run time and as a bonus you get 13 more emails. 🎉 


## Was README.md updated if necessary?

## Are there any configuration changes for shared_configs?
