### PR TITLE
changing embargo now requires versioning

### DIFF
--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -112,6 +112,13 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     # change embargo date
     new_embargo_date = Date.today + 3
     visit "#{Settings.argo_url}/view/#{bare_druid}"
+    # open a new version so we can manage embargo
+    click_link 'Unlock to make changes to this object'
+    within '.modal-dialog' do
+      select 'Admin', from: 'Type'
+      fill_in 'Version description', with: 'opening version for integration testing'
+      click_button 'Open Version'
+    end
     click_link 'Manage embargo'
     within '#modal-frame' do
       fill_in('Enter the date when this embargo ends', with: new_embargo_date.strftime('%F'))


### PR DESCRIPTION
## Why was this change made? 🤔

This recent change (sul-dlss/argo#3132) requires updating the tests to open a version before changing embargo

Note: the re-index seems to be flaky for me (i.e. it sometimes does not show the reindex message making the test get hung up here: https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/support/page_helpers.rb#L24 which is called from here: https://github.com/sul-dlss/infrastructure-integration-test/blob/main/spec/features/create_object_h2_spec.rb#L120-L121)

## Was README.md updated if necessary? 🤨


