### PR TITLE
Revert "Update dependencies for cocina-models update"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.2.3)
+    activesupport (7.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -24,7 +24,7 @@ GEM
       terminal-table
       xpath (>= 2.1)
     childprocess (4.1.0)
-    cocina-models (0.68.0)
+    cocina-models (0.67.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -42,9 +42,9 @@ GEM
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.5.0)
-    dor-services-client (8.2.0)
+    dor-services-client (8.1.1)
       activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.68.0)
+      cocina-models (~> 0.67.1)
       deprecation
       faraday (~> 2.0)
       faraday-retry
@@ -168,9 +168,9 @@ GEM
       nokogiri (>= 1.10.8)
       rubyzip (>= 1.3.0)
     rubyzip (2.3.2)
-    sdr-client (0.71.0)
+    sdr-client (0.69.1)
       activesupport
-      cocina-models (~> 0.68.0)
+      cocina-models (~> 0.67.1)
       dry-monads
       faraday (>= 0.16)
     selenium-webdriver (4.1.0)


### PR DESCRIPTION
Reverts sul-dlss/infrastructure-integration-test#370

d'oh, i realized as i merged that this the passing build was not a good measure of this PR working, will re-create the update PR with fixes after this undoes my bad merge