### PR TITLE
Use cocina-models 0.68 namespace for object type URI

### DIFF
--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -39,7 +39,7 @@ module DepositHelpers
     object_druid = deposit(apo: Settings.default_apo,
                            collection: Settings.default_collection,
                            url: Settings.sdrapi_url,
-                           type: Cocina::Models::Vocab.image,
+                           type: Cocina::Models::ObjectType.image,
                            source_id: "virtual-object-test:#{SecureRandom.uuid}",
                            accession: true,
                            access: 'world',


### PR DESCRIPTION
## Why was this change made? 🤔

To allow the tests to run against cocina-models 0.68.0

## Was README.md updated if necessary? 🤨

n/a
