### PR TITLE
Specifying bulk actions text to click

### DIFF
--- a/spec/features/edit_bulk_tags_spec.rb
+++ b/spec/features/edit_bulk_tags_spec.rb
@@ -22,8 +22,10 @@ RSpec.describe 'Use Argo to edit administrative tags in bulk', type: :feature do
     # Grab top three druids for testing bulk tag operation
     bulk_druids = all('dd.blacklight-id').take(number_of_druids).map(&:text)
 
-    click_link 'Bulk Actions'
-    expect(page).to have_content 'Bulk Actions'
+    within('.search-widgets') do
+      click_link 'Bulk Actions'
+    end
+    expect(page).to have_selector 'h1', text: 'Bulk Actions'
 
     click_link 'New Bulk Action'
     expect(page).to have_content 'New Bulk Action'


### PR DESCRIPTION
## Why was this change made? 🤔
Capybara needed more specific guidance on which of the renamed "Bulk Actions" links to click on or look for. Successfully ran on stage. 


## Was README.md updated if necessary? 🤨


