### PR TITLE
update tests to handle Argo's lazily loaded sections

### DIFF
--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe 'SDR deposit', type: :feature do
     # Tests existence of technical metadata
     expect(page).to have_content 'Technical metadata'
     click_button 'Technical metadata'
+
+    # this is a hack that forces the techMD section to scroll into view; the section
+    # is lazily loaded, and won't actually be requested otherwise, even if the button
+    # is clicked to expand the technical metadata section.
+    page.execute_script 'window.scrollBy(0,100);'
+
     within('#document-techmd-section') do
       file_listing = find_all('.file')
       expect(file_listing.size).to eq 2

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -6,12 +6,18 @@ module PageHelpers
       loop do
         if with_events_expanded
           click_button 'Events' # expand the Events section
+
+          # this is a hack that forces the event section to scroll into view; the section
+          # is lazily loaded, and won't actually be requested otherwise, even if the button
+          # is clicked to expand the event section.
+          page.execute_script 'window.scrollBy(0,100);'
         end
 
+        wait_time = with_events_expanded ? 3 : 1 # events are loaded lazily, give the network a few moments
         if as_link
-          break if page.has_link?(text, wait: 1)
+          break if page.has_link?(text, wait: wait_time)
         else
-          break if page.has_text?(text, wait: 1)
+          break if page.has_text?(text, wait: wait_time)
         end
 
         # Check for workflow errors and bail out early. There is no recovering


### PR DESCRIPTION
## Why was this change made? 🤔

A couple of tests broke due to the newly added lazy loading of the Events and Technical Metadata sections (Argo view page).

In both cases, I discovered that even if the section is expanded, the content doesn't actually load till it scrolls into view.  Since the Capybara-controlled browser only scrolls far enough to get a clicked element into view, clicking these section headers doesn't actually scroll the content into view (the section header starts out below the end of the viewport, so clicking it puts only the section header into the viewport).

Sort of lucky that I figured it out -- was tipped off when I put my cursor into the Capybara-controlled browser's viewport to scroll down a bit and see what Capybara saw at the moment in the events section (since all the events seemed to be there when i checked after the test failed)... and the moment I did that the previously failing test found what it was looking for and passed.

This fix feels a little hacky, so I'm happy to handle this differently if there's a better way.

## Was README.md updated if necessary? 🤨

N/A