### PR TITLE
Full host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Some integration tests use the `dor-services-client` to interact with the `dor-s
 
 ### Set ETD Credentials
 
-In order to run `spec/features/create_etd_spec.rb`, you will the ETD application's backdoor username and password for HTTP POST requests.  You'll need to get these valuse from shared_configs for the etd stage and qa branches, and add them to `config/settings/staging.local.yml` and `config/settings/qa.local.yml`.  See `config/settings.yml` for the expected YAML syntax.
+In order to run `spec/features/create_etd_spec.rb`, you will the ETD application's backdoor username and password for HTTP POST requests.  You'll need to get these values from the `sul-hydra-etd-stage` and `sul-hydra-etd-qa` branches of sul-dlss/shared_configs, and add them to `config/settings/staging.local.yml` and `config/settings/qa.local.yml` respectively.  See `config/settings.yml` for the expected YAML syntax.
 
 ### Problems with Authentication?
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -6,6 +6,6 @@ h2_url: 'https://sul-h2-qa.stanford.edu'
 # for purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
 purl_url: 'https://sul-purl-stage.stanford.edu'
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
-preassembly_host: 'sul-preassembly-qa'
+preassembly_host: 'sul-preassembly-qa.stanford.edu'
 preassembly_url: 'https://sul-preassembly-qa.stanford.edu'
 sdrapi_url: 'https://sdr-api-qa.stanford.edu'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -5,6 +5,6 @@ etd_url: 'https://etd-stage.stanford.edu'
 h2_url: 'https://sul-h2-stage.stanford.edu'
 purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
 preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
-preassembly_host: 'sul-preassembly-stage'
+preassembly_host: 'sul-preassembly-stage.stanford.edu'
 preassembly_url: 'https://sul-preassembly-stage.stanford.edu'
 sdrapi_url: 'https://sdr-api-stage.stanford.edu'


### PR DESCRIPTION
## Why was this change made? 🤔

Ensure that Settings.preassembly_host includes stanford.edu so that scp
command works reliably with the ssh config in the README.md:

```
Host *.stanford.edu
  GSSAPIDelegateCredentials yes
```

This will only delegate for the full hostname. I also fixed a typo and
provided a little bit more of a hint of where to find ETD
username/password.

## Was README.md updated if necessary? 🤨

Not needed! 


