### PR TITLE
[HOLD] update argo reg test for content type form update

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Create and re-accession object via Pre-assembly', type: :feature
     # register new object
     select 'integration-testing', from: 'Admin Policy'
     select 'integration-testing', from: 'Collection'
-    select 'Image', from: 'Content Type'
+    select 'image', from: 'Content Type'
     fill_in 'Project Name', with: 'Integration Test - Image via Preassembly'
     click_button 'Add another row'
     td_list = all('td.invalidDisplay')


### PR DESCRIPTION
## Why was this change made? 🤔

The way content types are selected in the Argo registration form is changing (because of sul-dlss/argo#3548).  This fixes the tests because of this change.
