### PR TITLE
wait for PURL page to be ready

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe 'Create and re-accession object via Pre-assembly', type: :feature
 
     # This section confirms the object has been published to PURL and has a
     # valid IIIF manifest
+    sleep 1 # noticed the PURL page took a bit longer to be ready
     visit "#{Settings.purl_url}/#{druid.delete_prefix('druid:')}"
     iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
     iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)


### PR DESCRIPTION
## Why was this change made? 🤔

The preassembly image test failed a couple times because the PURL page didn't seem to be quite ready when it tried to visit it.  Refreshing the test browser allowed the test to continue and pass.  This will give us a second to wait for that PULR page and should make this test less flaky.  I am not sure why it's not ready when the status in Argo says it is accessioned (it should be).

## Was README.md updated if necessary? 🤨


