### PR TITLE
randomize pre-assembly project name more

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'Create and re-accession object via Pre-assembly', type: :feature
 
     expect(page).to have_content 'Complete the form below'
 
-    fill_in 'Project name', with: random_noun
+    fill_in 'Project name', with: random_project_name
     select 'Pre Assembly Run', from: 'Job type'
     fill_in 'Bundle dir', with: preassembly_bundle_dir
     select 'Filename', from: 'Content metadata creation'

--- a/spec/support/random_phrase_helpers.rb
+++ b/spec/support/random_phrase_helpers.rb
@@ -18,4 +18,8 @@ module RandomPhraseHelpers
     3.times { nouns << Faker::Creature::Bird.common_name.to_s }
     nouns
   end
+
+  def random_project_name
+    "#{random_nouns_array.join('_')}_#{random_alpha}"
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

We are hitting issues with the pre-assembly project name not being unique, which means there is a directory conflict.  This further randomizes the project name when running the test.

Ran it once on -stage successfully.