### PR TITLE
fix create_apo_spec finding of Reindex button when waiting/reloading to look for 'v1 Accessioned' text

### DIFF
--- a/spec/features/create_apo_spec.rb
+++ b/spec/features/create_apo_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe 'Use Argo to create an APO and verify new objects inherit its rig
     expect(page).to have_content "APO #{apo_druid} created."
 
     # wait for accessioningWF to finish
+    # Without this page.refresh, selenium webdriver complained:
+    #  Element <a class="btn button btn-primary " href="/dor/reindex/druid:bc123df4567"> could not be scrolled into view
+    # Explicitly trying to scroll up via "page.execute_script 'window.scrollTo(0,0);'" did not seem to work.
+    page.refresh
     reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
 
     # now register an object with this apo and verify default rights


### PR DESCRIPTION
## Why was this change made? 🤔

couldn't get the spec to get past `reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)` without it.  otherwise, the test would hang, and fail with e.g.:

```
Failures:

  1) Use Argo to create an APO and verify new objects inherit its rights is expected not to have visible css ".alert-danger"
     Failure/Error: click_link 'Reindex'
     
     Selenium::WebDriver::Error::ElementNotInteractableError:
       Element <a class="btn button btn-primary " href="/dor/reindex/druid:hn320cy6096"> could not be scrolled into view
     # WebDriverError@chrome://remote/content/shared/webdriver/Errors.jsm:183:5
     # ElementNotInteractableError@chrome://remote/content/shared/webdriver/Errors.jsm:293:5
     # webdriverClickElement@chrome://remote/content/marionette/interaction.js:156:11
     # interaction.clickElement@chrome://remote/content/marionette/interaction.js:125:11
     # clickElement@chrome://remote/content/marionette/actors/MarionetteCommandsChild.jsm:203:24
     # receiveMessage@chrome://remote/content/marionette/actors/MarionetteCommandsChild.jsm:91:31
     # ./spec/support/page_helpers.rb:28:in `block (2 levels) in reload_page_until_timeout!'
     # ./spec/support/page_helpers.rb:6:in `loop'
     # ./spec/support/page_helpers.rb:6:in `block in reload_page_until_timeout!'
     # ./spec/support/page_helpers.rb:5:in `reload_page_until_timeout!'
     # ./spec/features/create_apo_spec.rb:34:in `block (2 levels) in <top (required)>'
```

## Was README.md updated if necessary? 🤨

n/a
