### PR TITLE
Just wait one time before examining the page

### DIFF
--- a/spec/features/create_preassembly_image_spec.rb
+++ b/spec/features/create_preassembly_image_spec.rb
@@ -86,15 +86,14 @@ RSpec.describe 'Create and re-accession object via Pre-assembly', type: :feature
     # ensure Image files are all there, per pre-assembly, organized into specified resources
     visit "#{Settings.argo_url}/view/#{druid}"
 
-    reload_page_until_timeout!(text: "Resource (1)\nimage\nLabel\nImage 1")
+    # Wait for accessioningWF to finish
+    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+
     files = all('tr.file')
 
     expect(files.size).to eq 2
     expect(files.first.text).to match(%r{image.jpg image/jpeg 28.\d KB})
     expect(files.last.text).to match(%r{image.jp2 image/jp2 64.\d KB})
-
-    # Wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
 
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('image') # filled in by accessioning
 


### PR DESCRIPTION
## Why was this change made? 🤔
In the future, when assemblyWF switches to cocina, we will see the content earlier, but it will still be in progress, so some expected values won't show until assemblyWF has completed.

See https://github.com/sul-dlss/common-accessioning/pull/919



## Was README.md updated if necessary? 🤨
n/a

