### PR TITLE
Press Enter key to submit search term

### DIFF
--- a/spec/features/create_object_h2_spec.rb
+++ b/spec/features/create_object_h2_spec.rb
@@ -87,8 +87,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
 
     # Opens Argo and searches on title
     visit Settings.argo_url
-    fill_in 'Search...', with: item_title
-    click_button 'Search'
+    find_field('Search...').send_keys(item_title, :enter)
     reload_page_until_timeout!(text: 'v1 Accessioned')
 
     # check Argo facet field with 6 month embargo
@@ -155,8 +154,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
 
     # Opens Argo and searches on title
     visit Settings.argo_url
-    fill_in 'Search...', with: item_title
-    click_button 'Search'
+    find_field('Search...').send_keys(item_title, :enter)
     reload_page_until_timeout!(text: 'v2 Accessioned')
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

before this fix, `create_object_h2_spec.rb` consistently failed with `Capybara::Ambiguous:`  `Ambiguous match, found 2 elements matching visible button "Search" that is not disabled` on the parts of this spec that i modified.

after this fix, `create_object_h2_spec.rb` consistently passes.

There are multiple buttons on the page that contain the text "Search" (the other is the "Released to Searchworks" facet).  But the current locator for finding and filling in the search box still finds exactly one element, and pressing the Enter key in it after filling it in submits the search form successfully.

(Finding based on exact text would also be tricky: I noticed when debugging that the actual text of the search box submission button, from the perspective of Capybara::Node::Element#text is "Search search icon" because of alt text and icon, even when the text is limited to what Capybara considers visible.)

## Was README.md updated if necessary? 🤨

n/a
