### PR TITLE
Switch wayback URLs to the new post-migration URLs

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -9,7 +9,7 @@ preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-qa.stanford.edu'
 preassembly_url: 'https://sul-preassembly-qa.stanford.edu'
 sdrapi_url: 'https://sdr-api-qa.stanford.edu'
-was_playback_url: 'https://was-pywb-qa.stanford.edu'
+was_playback_url: 'https://swap-qa.stanford.edu'
 was_registrar:
   host: 'was-registrar-app-qa.stanford.edu'
   jobs_directory: '/was_unaccessioned_data/jobs'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -8,7 +8,7 @@ preassembly_bundle_directory: '/dor/staging/integration-tests/image-test'
 preassembly_host: 'sul-preassembly-stage.stanford.edu'
 preassembly_url: 'https://sul-preassembly-stage.stanford.edu'
 sdrapi_url: 'https://sdr-api-stage.stanford.edu'
-was_playback_url: 'https://was-pywb-stage.stanford.edu'
+was_playback_url: 'https://swap-stage.stanford.edu'
 was_registrar:
   host: 'was-registrar-app-stage.stanford.edu'
   jobs_directory: '/was_unaccessioned_data/jobs'


### PR DESCRIPTION
Confirmed working by running against stage.

## Why was this change made? 🤔

Use the URLs we actually use.
