### PR TITLE
output druids for "when tests go bad"

### DIFF
--- a/spec/features/access_indexing_spec.rb
+++ b/spec/features/access_indexing_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'Argo rights changes result in correct Access Rights facet value'
     expect(page).to have_text 'Items successfully registered.'
 
     bare_object_druid = find('table a').text
+    puts " *** access indexing druid: #{bare_object_druid} ***" # useful for debugging
     object_druid = "druid:#{bare_object_druid}"
-    # puts "object_druid: #{object_druid}" # useful for debugging
 
     visit "#{Settings.argo_url}/view/#{object_druid}"
 

--- a/spec/features/apo_creation_spec.rb
+++ b/spec/features/apo_creation_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe 'Use Argo to create an APO and verify new objects inherit its rig
     expect(page).to have_text 'Items successfully registered.'
 
     bare_object_druid = find('table a').text
+    puts " *** APO creation druid: #{bare_object_druid} ***" # useful for debugging
     object_druid = "druid:#{bare_object_druid}"
-    # puts "object_druid: #{object_druid}" # useful for debugging
 
     visit "#{Settings.argo_url}/view/#{object_druid}"
 

--- a/spec/features/bulk_tags_edit_spec.rb
+++ b/spec/features/bulk_tags_edit_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Use Argo to edit administrative tags in bulk', type: :feature do
   scenario 'exports tags to CSV and then imports them' do
     # Grab top three druids for testing bulk tag operation
     bulk_druids = all('dd.blacklight-id').take(number_of_druids).map(&:text)
+    puts " *** bulk tags edit druids: #{bulk_druids.join(', ')} ***" # useful for debugging
 
     within('.search-widgets') do
       click_link 'Bulk Actions'

--- a/spec/features/bulk_update_metadata_spec.rb
+++ b/spec/features/bulk_update_metadata_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
   scenario do
     druid1 = create_druid
     druid2 = create_druid
+    puts " *** bulk update metadata druids: #{druid1}, #{druid2} ***" # useful for debugging
     temp_xlsx = update_xlsx(druid1, title1, druid2, title2)
 
     visit "#{Settings.argo_url}/view/#{Settings.default_apo}"

--- a/spec/features/bulk_update_metadata_spec.rb
+++ b/spec/features/bulk_update_metadata_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Use Argo to upload metadata in a spreadsheet', type: :feature do
+RSpec.describe 'Use Argo to update metadata in a spreadsheet (using modsulator)', type: :feature do
   let(:title1) { random_phrase }
   let(:title2) { random_phrase }
   let(:note) { random_phrase }

--- a/spec/features/collection_creation_spec.rb
+++ b/spec/features/collection_creation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Use Argo to create a collection from APO page', type: :feature do
+RSpec.describe 'Use Argo to create a collection', type: :feature do
   let(:collection_title) { random_phrase }
   let(:collection_abstract) { 'Created by https://github.com/sul-dlss/infrastructure-integration-test' }
   let(:start_url) { "#{Settings.argo_url}/view/#{Settings.default_apo}" }

--- a/spec/features/collection_creation_spec.rb
+++ b/spec/features/collection_creation_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Use Argo to create a collection from APO page', type: :feature d
     expect(page).to have_content 'Created collection'
 
     collection_druid = find('.alert-info').text.split[2]
+    puts " *** collection creation druid: #{collection_druid} ***" # useful for debugging
     visit "#{Settings.argo_url}/view/#{collection_druid}"
 
     expect(page).to have_content collection_title

--- a/spec/features/create_object_no_files_spec.rb
+++ b/spec/features/create_object_no_files_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe 'Use Argo to create an object without any files', type: :feature 
     expect(page).to have_text 'Items successfully registered.'
 
     bare_object_druid = find('table a').text
+    puts " *** create object no files druid: #{bare_object_druid} ***" # useful for debugging
     object_druid = "druid:#{bare_object_druid}"
-    # puts "object_druid: #{object_druid}" # useful for debugging
 
     visit "#{Settings.argo_url}/view/#{object_druid}"
 

--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe 'Create a new ETD', type: :feature do
     resp_body = simulate_registrar_post(initial_xml_from_registrar)
     prefixed_druid = resp_body.split.first
     expect(prefixed_druid).to start_with('druid:')
-    # puts "dissertation id is #{dissertation_id}" # helpful for debugging
-    # puts "druid is #{prefixed_druid}" # helpful for debugging
+    puts " *** ETD creation druid: #{prefixed_druid} ***" # useful for debugging
+    # puts "   *** dissertation id is #{dissertation_id} ***" # helpful for debugging
 
     etd_submit_url = "#{Settings.etd_url}/submit/#{prefixed_druid}"
     # puts "etd submit url: #{etd_submit_url}" # helpful for debugging

--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Create a new ETD', type: :feature do
+RSpec.describe 'Create a new ETD with embargo, and then update the embargo date', type: :feature do
   now = '' # used for HEREDOC reader and registrar approved xml (can't be memoized)
 
   # dissertation id must be unique; D followed by 9 digits, e.g. D123456789

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -33,9 +33,8 @@ RSpec.describe 'Create and accession GIS object', type: :feature,
     expect(page).to have_text 'Items successfully registered.'
 
     bare_object_druid = find('table a').text
+    puts " *** GIS accessioning druid: #{bare_object_druid} ***" # useful for debugging
     druid = "druid:#{bare_object_druid}"
-
-    # # puts druid # useful for debugging
 
     # Go to kurma server and copy test content to the druid folder so it can be accessioned
     test_data_source_folder = File.join(Settings.gis.robots_content_root, 'integration_test_data')

--- a/spec/features/goobi_accessioning_spec.rb
+++ b/spec/features/goobi_accessioning_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe 'Create and accession object via Goobi', type: :feature,
     expect(page).to have_text 'Items successfully registered.'
 
     bare_object_druid = find('table a').text
+    puts " *** goobi accessioning druid: #{bare_object_druid} ***" # useful for debugging
     druid = "druid:#{bare_object_druid}"
-
-    # puts druid # useful for debugging
 
     # wait to be sure goobiWF has finished running and goobi has time to process the incoming object
     sleep 2

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe 'Use H2 to create an object', type: :feature do
     embargo_date = DateTime.now.getutc.to_date >> 6
     expect(page).to have_content("Embargoed until #{embargo_date.to_formatted_s(:long)}")
     bare_druid = page.current_url.split(':').last
+    puts " *** h2 object creation druid: #{bare_druid} ***" # useful for debugging
 
     # check purl xml for embargo
     expect_embargo_date_in_public_xml(bare_druid, embargo_date)

--- a/spec/features/preasssembly_image_accessioning_spec.rb
+++ b/spec/features/preasssembly_image_accessioning_spec.rb
@@ -49,9 +49,8 @@ RSpec.describe 'Create and re-accession object via Pre-assembly', type: :feature
     expect(page).to have_text 'Items successfully registered.'
 
     bare_object_druid = find('table a').text
+    puts " *** preassembly image accessioning druid: #{bare_object_druid} ***" # useful for debugging
     druid = "druid:#{bare_object_druid}"
-
-    # puts druid # useful for debugging
 
     # create manifest.csv file and scp it to preassembly staging directory
     File.write(local_manifest_location, preassembly_manifest_csv)

--- a/spec/features/preasssembly_image_accessioning_spec.rb
+++ b/spec/features/preasssembly_image_accessioning_spec.rb
@@ -4,7 +4,7 @@ require 'druid-tools'
 
 # Preassembly requires that files to be included in an object must be available on a mounted drive
 # To this end, files have been placed on Settings.preassembly_host at Settings.preassembly_bundle_directory
-RSpec.describe 'Create and re-accession object via Pre-assembly', type: :feature do
+RSpec.describe 'Create and re-accession image object via Pre-assembly', type: :feature do
   druid = '' # used for HEREDOC preassembly manifest files (can't be memoized)
 
   let(:start_url) { "#{Settings.argo_url}/registration" }

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'SDR deposit', type: :feature do
                              'Gemfile' => { 'preserve' => true },
                              'Gemfile.lock' => { 'preserve' => true }
                            })
+    puts " *** sdr deposit druid: #{druid} ***" # useful for debugging
 
     visit "#{start_url}/view/#{object_druid}?beta=true"
 

--- a/spec/features/virtual_object_creation_spec.rb
+++ b/spec/features/virtual_object_creation_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'Use Argo to create a virtual object with constituent objects', t
 
     # Create virtual object
     virtual_object_druid = deposit_object
+    puts " *** virtual object druid: #{virtual_object_druid} ***" # useful for debugging
 
     # Create constituent objects
     constituent_druids = []
@@ -26,6 +27,7 @@ RSpec.describe 'Use Argo to create a virtual object with constituent objects', t
     end
 
     puts constituent_druids
+    puts "   *** constituent object druids: #{constituent_druids.join(', ')} ***" # useful for debugging
 
     # Create CSV: virtual_object_druid, constituent_druid, constituent_druid
     virtual_object_row = constituent_druids.clone

--- a/spec/features/web_archive_accessioning_spec.rb
+++ b/spec/features/web_archive_accessioning_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     reload_page_until_timeout!(text: 'success: Created', table: { 'Job directory' => job_specific_directory })
 
     crawl_druid = find(:table_row, { 'Job directory' => job_specific_directory }).text.split.last
+    puts " *** was crawl druid: #{crawl_druid} ***" # useful for debugging
     visit "#{Settings.argo_url}/view/#{crawl_druid}"
 
     expect(page).to have_content(job_specific_directory)
@@ -78,6 +79,7 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     expect(page).to have_text 'Items successfully registered.'
 
     seed_druid = find('table a').text
+    puts " *** was seed druid: #{seed_druid} ***" # useful for debugging
 
     visit "#{Settings.argo_url}/view/#{seed_druid}"
     content_type_element = find_table_cell_following(header_text: 'Content type')


### PR DESCRIPTION
## Why was this change made? 🤔

So we don't have to fuss with cut and paste from the browser window for tests in progress.

Also updated a few spec descriptions

## Was README.md updated if necessary? 🤨


