### PR TITLE
Fix ETD Flaky Spec

### DIFF
--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -181,7 +181,8 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
     # fake reader approval
     reader_progress_list_el = all('#progressBoxContent > ol > li')[9]
     expect(reader_progress_list_el).to have_text("Verified by Final Reader\n- Not done")
-    now = Time.now.in_time_zone('America/Los_Angeles').strftime('%m/%d/%Y %T')
+    # the faked reader approval time should be sufficiently past the submitted time to ensure it sticks
+    now = (Time.now + 3600).in_time_zone('America/Los_Angeles').strftime('%m/%d/%Y %T')
     resp_body = simulate_registrar_post(reader_approval_xml_from_registrar)
     expect(resp_body).to eq "#{prefixed_druid} updated"
     page.refresh # needed to show updated progress box
@@ -191,7 +192,8 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
     # fake registrar approval
     registrar_progress_list_el = all('#progressBoxContent > ol > li')[10]
     expect(registrar_progress_list_el).to have_text("Approved by Registrar\n- Not done")
-    now = Time.now.in_time_zone('America/Los_Angeles').strftime('%m/%d/%Y %T')
+    # the faked registrar approval time should be sufficiently past the submitted time to ensure it sticks
+    now = (Time.now + 7200).in_time_zone('America/Los_Angeles').strftime('%m/%d/%Y %T')
     resp_body = simulate_registrar_post(registrar_approval_xml_from_registrar)
     expect(resp_body).to eq "#{prefixed_druid} updated"
     page.refresh # needed to show updated progress box


### PR DESCRIPTION
## Why was this change made? 🤔

Fake etd approvals need to happen more than 1 second after submission for them to stick

See https://github.com/sul-dlss/hydra_etd/blob/main/app/services/registrar_data_importer.rb#L150-L160 

If submission and update are too close together, this logic can sometimes return false, causing the faked approval/updates to not be saved.
