### PR TITLE
Update authentication to add brower trust button step

### DIFF
--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -27,7 +27,7 @@ module AuthenticationHelpers
     # We're at the Stanford login page
     fill_in 'SUNet ID', with: username
     fill_in 'Password', with: password
-    sleep 1
+    # sleep 1 # mjgiarlo found he didn't need this on 2022/11/07 so commenting out
     click_button 'Login'
 
     if Settings.automatic_authentication
@@ -48,6 +48,8 @@ module AuthenticationHelpers
         click_button 'Send Me a Push'
       end
     end
+
+    click_button 'Yes, trust browser'
   end
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
## Why was this change made? 🤔

This is a new step, apparently. Also, the nearby sleep appears no longer to be needed. Leaving commented out in case someone else runs into auth issues in the near future, as a clue for them to follow.


## Was README.md updated if necessary? 🤨

no
