### PR TITLE
Make the tests faster, more reliable, and easier to extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In order to run `spec/features/goobi_accessioning_spec.rb`, you need the Goobi a
 
 ### Problems with Authentication?
 
-You may want to lower the timeout value of `post_authentication_text_timeout` in `config/settings.local.yml`.
+You may want to lower the timeout value of `Settings.timeouts.post_authentication_text` in `config/settings.local.yml`.
 
 ## Other Configuration
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,8 @@
-timeouts:
+timeouts:  # in seconds
   capybara: 60
   workflow: 300
   bulk_action: 200
+  post_authentication_text: 5
   events:
     poll_for: 240
     poll_interval: 2
@@ -16,8 +17,6 @@ default_collection: 'druid:bc778pm9866'
 
 # For virtual object testing
 number_of_constituents: 2
-
-post_authentication_text_timeout: 5 # in seconds
 
 supported_envs:
   - qa

--- a/spec/features/access_indexing_spec.rb
+++ b/spec/features/access_indexing_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Argo rights changes result in correct Access Rights facet value'
     visit "#{Settings.argo_url}/view/#{object_druid}"
 
     # wait for registrationWF to finish
-    reload_page_until_timeout!(text: 'v1 Registered', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Registered')
 
     find_access_rights_single_facet_value(object_druid, 'world')
 

--- a/spec/features/apo_creation_spec.rb
+++ b/spec/features/apo_creation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Use Argo to create an APO and verify new objects inherit its rig
     #  Element <a class="btn button btn-primary " href="/dor/reindex/druid:bc123df4567"> could not be scrolled into view
     # Explicitly trying to scroll up via "page.execute_script 'window.scrollTo(0,0);'" did not seem to work.
     page.refresh
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     # now register an object with this apo and verify default rights
     visit "#{Settings.argo_url}/registration"
@@ -57,7 +57,7 @@ RSpec.describe 'Use Argo to create an APO and verify new objects inherit its rig
     visit "#{Settings.argo_url}/view/#{object_druid}"
 
     # wait for registrationWF to finish and verify default access rights
-    reload_page_until_timeout!(text: 'v1 Registered', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Registered')
     expect(find_table_cell_following(header_text: 'Access rights').text).to eq("View: #{rights}, Download: #{rights}")
 
     expect(page).to have_text(terms_of_use)

--- a/spec/features/collection_creation_spec.rb
+++ b/spec/features/collection_creation_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe 'Use Argo to create a collection' do
     expect(apo_element.first('a')[:href]).to end_with(Settings.default_apo)
 
     # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
   end
 end

--- a/spec/features/create_object_no_files_spec.rb
+++ b/spec/features/create_object_no_files_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Use Argo to create an item object without any files' do
     visit "#{Settings.argo_url}/view/#{object_druid}"
 
     # wait for registrationWF to finish
-    reload_page_until_timeout!(text: 'v1 Registered', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Registered')
 
     # add accessionWF
     click_link 'Add workflow'
@@ -50,7 +50,7 @@ RSpec.describe 'Use Argo to create an item object without any files' do
     expect(page).to have_text("Registered By : #{AuthenticationHelpers.username}")
 
     # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     # open a new version
     click_link 'Unlock to make changes to this object'
@@ -72,6 +72,6 @@ RSpec.describe 'Use Argo to create an item object without any files' do
     page.refresh # solves problem of close version modal re-appearing
 
     # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v2 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v2 Accessioned')
   end
 end

--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -249,8 +249,7 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
     click_button 'Save'
 
     page.refresh # solves problem of update embargo modal re-appearing
-    reload_page_until_timeout!(text: "Embargoed until #{new_embargo_date.to_formatted_s(:long)}",
-                               with_reindex: true)
+    reload_page_until_timeout!(text: "Embargoed until #{new_embargo_date.to_formatted_s(:long)}")
 
     # check Argo facet field with 3 day embargo
     fill_in 'Search...', with: prefixed_druid

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Create and accession GIS item object', if: ENV.fetch('SDR_ENV', 
     click_button 'Add'
     expect(page).to have_text('Added gisAssemblyWF')
     # verify the workflow completes
-    reload_page_until_timeout!(text: 'completed', selector: '#workflow-details-status-gisAssemblyWF', with_reindex: true)
+    reload_page_until_timeout!(text: 'completed', selector: '#workflow-details-status-gisAssemblyWF')
 
     # add gisDeliveryWF
     click_link 'Add workflow'
@@ -65,7 +65,7 @@ RSpec.describe 'Create and accession GIS item object', if: ENV.fetch('SDR_ENV', 
     click_link 'gisDeliveryWF'
     click_button 'workflow-status-set-reset-geowebcache-completed'
     # verify the workflow completes
-    reload_page_until_timeout!(text: 'completed', selector: '#workflow-details-status-gisDeliveryWF', with_reindex: true)
+    reload_page_until_timeout!(text: 'completed', selector: '#workflow-details-status-gisDeliveryWF')
 
     # add accessionWF
     click_link 'Add workflow'
@@ -73,7 +73,7 @@ RSpec.describe 'Create and accession GIS item object', if: ENV.fetch('SDR_ENV', 
     click_button 'Add'
     expect(page).to have_text('Added accessionWF')
     # Wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     # look for expected files produced by GIS workflows
     files = all('tr.file')

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe 'Create and accession GIS item object', if: ENV.fetch('SDR_ENV', 
     click_button 'Add'
     expect(page).to have_text('Added gisAssemblyWF')
     # verify the workflow completes
-    reload_page_until_timeout!(text: 'completed', selector: '#workflow-details-status-gisAssemblyWF')
+    reload_page_until_timeout! do
+      page.has_selector?('#workflow-details-status-gisAssemblyWF', text: 'completed', wait: 1)
+    end
 
     # add gisDeliveryWF
     click_link 'Add workflow'
@@ -65,7 +67,9 @@ RSpec.describe 'Create and accession GIS item object', if: ENV.fetch('SDR_ENV', 
     click_link 'gisDeliveryWF'
     click_button 'workflow-status-set-reset-geowebcache-completed'
     # verify the workflow completes
-    reload_page_until_timeout!(text: 'completed', selector: '#workflow-details-status-gisDeliveryWF')
+    reload_page_until_timeout! do
+      page.has_selector?('#workflow-details-status-gisDeliveryWF', text: 'completed', wait: 1)
+    end
 
     # add accessionWF
     click_link 'Add workflow'

--- a/spec/features/goobi_accessioning_spec.rb
+++ b/spec/features/goobi_accessioning_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'Create and accession object via Goobi', if: ENV.fetch('SDR_ENV',
     visit "#{Settings.argo_url}/view/#{druid}"
 
     # Wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     # look for expected files
     files = all('tr.file')

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
 
   scenario do
     # remove modal for deposit in progress, if present, waiting a bit for some rendering
-    click_button 'No' if page.has_text?('Continue your deposit', wait: Settings.post_authentication_text_timeout)
+    click_button 'No' if page.has_text?('Continue your deposit', wait: Settings.timeouts.post_authentication_text)
 
     # CREATE COLLECTION
     click_link '+ Create a new collection'

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -141,8 +141,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
       fill_in('Enter the date when this embargo ends', with: new_embargo_date.strftime('%F'))
       click_button 'Save'
     end
-    reload_page_until_timeout!(text: "Embargoed until #{new_embargo_date.to_formatted_s(:long)}",
-                               with_reindex: true)
+    reload_page_until_timeout!(text: "Embargoed until #{new_embargo_date.to_formatted_s(:long)}")
 
     # check Argo facet field with 3 day embargo
     fill_in 'Search...', with: bare_druid

--- a/spec/features/preassembly_image_accessioning_spec.rb
+++ b/spec/features/preassembly_image_accessioning_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     visit "#{Settings.argo_url}/view/#{druid}"
 
     # Wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     files = all('tr.file')
 
@@ -135,7 +135,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     latest_version = version + 1
 
     visit "#{Settings.argo_url}/view/#{prefixed_druid}"
-    reload_page_until_timeout!(text: "v#{latest_version} Accessioned", with_reindex: true)
+    reload_page_until_timeout!(text: "v#{latest_version} Accessioned")
 
     # This section confirms the object has been published to PURL and has a
     # valid IIIF manifest

--- a/spec/features/preassembly_image_accessioning_spec.rb
+++ b/spec/features/preassembly_image_accessioning_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     expect(page).to have_text preassembly_project_name
 
     # wait for preassembly background job to finish
-    reload_page_until_timeout!(text: 'Download', as_link: true)
+    reload_page_until_timeout! do
+      page.has_link?('Download', wait: 1)
+    end
 
     click_link 'Download'
     wait_for_download
@@ -122,7 +124,9 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
 
     first('td > a').click # Click to the job details page
 
-    reload_page_until_timeout!(text: 'Download', as_link: true)
+    reload_page_until_timeout! do
+      page.has_link?('Download', wait: 1)
+    end
 
     click_link 'Download'
 
@@ -135,7 +139,17 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     latest_version = version + 1
 
     visit "#{Settings.argo_url}/view/#{prefixed_druid}"
-    reload_page_until_timeout!(text: "v#{latest_version} Accessioned")
+    reload_page_until_timeout! do
+      click_button 'Events' # expand the Events section
+
+      # this is a hack that forces the event section to scroll into view; the section
+      # is lazily loaded, and won't actually be requested otherwise, even if the button
+      # is clicked to expand the event section.
+      page.execute_script 'window.scrollBy(0,100);'
+
+      # events are loaded lazily, give the network a few moments
+      page.has_text?("v#{latest_version} Accessioned", wait: 3)
+    end
 
     # This section confirms the object has been published to PURL and has a
     # valid IIIF manifest
@@ -161,7 +175,17 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     druid_tree_str = DruidTools::Druid.new(prefixed_druid).tree.join('/')
 
     latest_s3_key = "#{druid_tree_str}.v000#{latest_version}.zip"
-    reload_page_until_timeout!(text: latest_s3_key, with_events_expanded: true)
+    reload_page_until_timeout! do
+      click_button 'Events' # expand the Events section
+
+      # this is a hack that forces the event section to scroll into view; the section
+      # is lazily loaded, and won't actually be requested otherwise, even if the button
+      # is clicked to expand the event section.
+      page.execute_script 'window.scrollBy(0,100);'
+
+      # events are loaded lazily, give the network a few moments
+      page.has_text?(latest_s3_key, wait: 3)
+    end
 
     # the event log should eventually contain an event for replication of each version that
     # this test created to every endpoint we archive to

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'SDR deposit' do
     visit "#{start_url}/view/#{object_druid}"
 
     # Wait for indexing and workflows to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     expect(page).to have_text 'The means to prosperity'
 

--- a/spec/features/virtual_object_creation_spec.rb
+++ b/spec/features/virtual_object_creation_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'Use Argo to create a virtual object with constituent objects' do
     end
 
     visit "#{start_url}/view/#{virtual_object_druid}"
-    reload_page_until_timeout!(text: 'v2 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v2 Accessioned')
 
     # Confirm constituent druids are listed in Content
     resources_text = all('.external-file a').map(&:text)

--- a/spec/features/web_archive_accessioning_spec.rb
+++ b/spec/features/web_archive_accessioning_spec.rb
@@ -46,7 +46,12 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     expect(page).to have_text('Queueing one-time registration.')
 
     # wait for registration to complete
-    reload_page_until_timeout!(text: 'success: Created', table: { 'Job directory' => job_specific_directory })
+    reload_page_until_timeout! do
+      page
+        .find(:table_row, { 'Job directory' => job_specific_directory })
+        .text
+        .match?('success: Created')
+    end
 
     crawl_druid = find(:table_row, { 'Job directory' => job_specific_directory }).text.split.last
     puts " *** was crawl druid: #{crawl_druid} ***" # useful for debugging

--- a/spec/features/web_archive_accessioning_spec.rb
+++ b/spec/features/web_archive_accessioning_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     expect(content_type_element.text).to eq('webarchive-binary')
 
     # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     expect(page).to have_link('wasCrawlPreas')
 
@@ -87,7 +87,7 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     expect(content_type_element.text).to eq('webarchive-seed')
 
     # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     expect(page).to have_link('thumbnail.jp2')
     expect(page).to have_text('image/jp2')

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -7,7 +7,7 @@ module AuthenticationHelpers
     # View the specified starting URL
     visit start_url
 
-    return if page.has_text?(expected_text, wait: Settings.post_authentication_text_timeout)
+    return if page.has_text?(expected_text, wait: Settings.timeouts.post_authentication_text)
 
     submit_credentials
 
@@ -21,7 +21,7 @@ module AuthenticationHelpers
     self.username ||= username_from_config_or_prompt
     self.password ||= password_from_config_or_prompt
 
-    if page.has_text?('SUNet ID', wait: Settings.post_authentication_text_timeout)
+    if page.has_text?('SUNet ID', wait: Settings.timeouts.post_authentication_text)
       fill_in 'SUNet ID', with: username
       fill_in 'Password', with: password
       click_button 'Login'

--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -52,7 +52,7 @@ module DepositHelpers
     visit "#{start_url}/view/#{object_druid}"
 
     # Wait for indexing and workflows to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned', with_reindex: true)
+    reload_page_until_timeout!(text: 'v1 Accessioned')
 
     object_druid
   end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,32 +1,10 @@
 # frozen_string_literal: true
 
 module PageHelpers
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/ParameterLists
-  def reload_page_until_timeout!(text:, as_link: false, table: nil, with_events_expanded: false, selector: nil)
+  def reload_page_until_timeout!(text: '')
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
-        if with_events_expanded
-          click_button 'Events' # expand the Events section
-
-          # this is a hack that forces the event section to scroll into view; the section
-          # is lazily loaded, and won't actually be requested otherwise, even if the button
-          # is clicked to expand the event section.
-          page.execute_script 'window.scrollBy(0,100);'
-        end
-
-        wait_time = with_events_expanded ? 3 : 1 # events are loaded lazily, give the network a few moments
-        if as_link
-          break if page.has_link?(text, wait: wait_time)
-        elsif table
-          break if page.find(:table_row, table).text.match?(text)
-        elsif selector
-          break if page.has_selector?(selector, text:, wait: wait_time)
-        else
-          break if page.has_text?(text, wait: wait_time)
-        end
+        break if block_given? ? yield : page.has_text?(text, wait: 1)
 
         # Check for workflow errors and bail out early. There is no recovering
         # from a workflow error. This selector is found on the Argo item page.
@@ -36,8 +14,4 @@ module PageHelpers
       end
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/ParameterLists
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -5,8 +5,7 @@ module PageHelpers
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/ParameterLists
-  def reload_page_until_timeout!(text:, as_link: false, table: nil, with_reindex: false, with_events_expanded: false,
-                                 selector: nil)
+  def reload_page_until_timeout!(text:, as_link: false, table: nil, with_events_expanded: false, selector: nil)
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
         if with_events_expanded
@@ -33,11 +32,6 @@ module PageHelpers
         # from a workflow error. This selector is found on the Argo item page.
         expect(page).not_to have_css('.alert-danger', wait: 0)
 
-        if with_reindex
-          click_link 'Reindex'
-          # ensure we see this message before we do the next thing
-          expect(page).to have_text('Successfully updated index for')
-        end
         page.refresh
       end
     end


### PR DESCRIPTION
# Why was this change made? 🤔

See above. Changes included:

* Remove `with_reindex` arg from reload_page_until_timeout helper
  * I added this ability a long time ago when indexing Fedora changes into Solr took more time, but I suspected it was no longer necessary and causes more clicks and uses more resources than is necessary. Upon removing this ability, I found that the test runtime is more or less unaffected.
* Move post-authentication timeout into configuration block
  * This commit moves a stray timeout into a block of similar timeouts in the application config. This keeps the configuration organized and consistent, making it easier to see all overrideable timeouts at a glance.
* Speed up and robustify ETD creation spec
  * This commit contains a number of changes related to improving the reliability and runtime speed of the ETD creation spec, including:
    * Reducing the time the test waits for negative expectations ("expect text NOT to appear"), where there is no need to wait longer than a second. Without this change, Capybara will wait until the default max wait time making the test take longer without any benefit(the page does not change underneath it, so waiting does not make sense in this context)
    * Dumbing down the embargo test somewhat, due to an occasional and annoying behavior where the embargo date is one day off. Dates and times are hard. Seeing this fail does not help anyone.
    * Forcing a reauthentication check when hitting Argo in the ETD spec. Without this, I was occasionally seeing behavior where ETD was authenticated but Argo was not, and moving over to Argo without going through the re-auth procedure caused a reproducible test timeout due to waiting on an unexpected Shib page.
* Refactor reload page helper
  * The `#reload_page_until_timeout!` method has become a bit of a beast whose behavior depends primarily on which arguments it is provided and the order the code checks those args. It is clear now that the best way to extend this method for all the different use cases it supports is to give it a single default behavior (check text on a page) and to allow consumers to provide a block for special behavior. This is a clearer way to extend Ruby methods to new use cases and is more Rubyish.

# Was README.md updated if necessary? 🤨

Yes.
