### PR TITLE
do an exact match for titles of test objects

### DIFF
--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
 
     # Opens Argo and searches on title
     visit Settings.argo_url
-    find_field('Search...').send_keys(item_title, :enter)
+    find_field('Search...').send_keys("\"#{item_title}\"", :enter)
     reload_page_until_timeout!(text: 'v1 Accessioned')
 
     # create a new version
@@ -104,7 +104,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
 
     # Opens Argo and searches on title
     visit Settings.argo_url
-    find_field('Search...').send_keys(item_title, :enter)
+    find_field('Search...').send_keys("\"#{item_title}\"", :enter)
     reload_page_until_timeout!(text: 'v2 Accessioned')
 
     # check Argo facet field with 6 month embargo


### PR DESCRIPTION
## Why was this change made? 🤔

It is safer to do an exact match search in Argo for the test H2 objects we are creating in the tests, or else we might get two results, confusing the test selectors.

e.g. https://argo-qa.stanford.edu/catalog?search_field=text&q=SUL+Logo+for+Balti+Stir+Fry+Mix+Cornichons

![Screen Shot 2022-11-17 at 1 03 10 PM](https://user-images.githubusercontent.com/47137/202559270-4f4afa7e-fe64-49c2-bac8-14c811509613.png)



