### PR TITLE
address some issues with H2 test flakiness

### DIFF
--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -93,6 +93,10 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     find_field('Search...').send_keys("\"#{item_title}\"", :enter)
     reload_page_until_timeout!(text: 'v1 Accessioned')
 
+    # give perservation a chance to catch up before we create a new version
+    #  since the shelving step does diffs that depend on files being visible in preservation
+    sleep 5
+
     # create a new version
     visit "#{Settings.h2_url}/dashboard"
     click_link "Edit #{item_title}"
@@ -110,7 +114,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     # check Argo facet field with 6 month embargo
     click_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do
-      expect(page).not_to have_text('up to 7 days')
+      expect(page).not_to have_text('up to 7 days', wait: 0)
     end
 
     # Click on link with the item's title in the search results


### PR DESCRIPTION
## Why was this change made? 🤔

1. Set a specific "wait" time of 0 when checking that an element is not on the page (else we wait for a long time even though it was never there and never will be).
2. There appears to be a race condition in the accessionWF#shelve step.  I don't fully understand it, but this step makes a single call to dor-services-app, which then starts a job, which then uses `ShelvingService` in dor-services-app, which does some content diffing and copying and expects files to be available in preservation.  The theory is that If we create a V2 immediately after accessioning a V1, perhaps preservation needs a few more seconds to catch up and show the files as available.  It always fails for me with no sleep (and I can get it to continue by manually reseting the step in a separate browser).  Putting a sleep of 3 seconds mostly worked, I haven't seen it fail with 5 seconds.  

see https://github.com/sul-dlss/dor-services-app/blob/main/app/services/shelving_service.rb#L19-L34 and https://github.com/sul-dlss/dor-services-app/blob/main/app/services/shelvable_files_stager.rb#L21-L35 for relevant parts of code that cause the failure

Could use a better solution/investigation for point 2, but at least this allows the test to pass.



## Was README.md updated if necessary? 🤨


