### PR TITLE
Authentication fixups

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,8 @@ timeouts:
   events:
     poll_for: 240
     poll_interval: 2
+  etd:
+    embargo_poll_interval: 1
 
 browser:
   driver: firefox

--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -207,12 +207,13 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
         visit "#{Settings.argo_url}/view/#{prefixed_druid}"
-        break if page.has_text?("Embargoed until #{embargo_date.to_formatted_s(:long)}", wait: 1)
+        break if page.has_text?("Embargoed until #{embargo_date.to_formatted_s(:long)}",
+                                wait: Settings.timeouts.etd.embargo_poll_interval)
       end
     end
     expect(page).to have_text(dissertation_title)
     apo_element = find_table_cell_following(header_text: 'Admin policy')
-    expect(apo_element.first('a')[:href]).to have_text('druid:bx911tp9024') # this is hardcoded in hydra_etd app
+    expect(apo_element.first('a')[:href]).to include('druid:bx911tp9024') # this is hardcoded in hydra_etd app
     status_element = find_table_cell_following(header_text: 'Status')
     expect(status_element).to have_text('v1 Registered')
     click_link('etdSubmitWF')

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
   let(:user_email) { "#{AuthenticationHelpers.username}@stanford.edu" }
 
   before do
-    authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: 'Dashboard')
+    authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: /Dashboard|Continue your deposit/)
   end
 
   scenario do

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     find_field('Search...').send_keys("\"#{item_title}\"", :enter)
     reload_page_until_timeout!(text: 'v1 Accessioned')
 
-    # give perservation a chance to catch up before we create a new version
+    # give preservation a chance to catch up before we create a new version
     #  since the shelving step does diffs that depend on files being visible in preservation
     sleep 5
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -4,30 +4,20 @@ module AuthenticationHelpers
   mattr_accessor :username, :password, :token
 
   def authenticate!(start_url:, expected_text:)
+    ensure_username! # sunet is needed by some tests, even if the user doesn't have to enter user/pass for Stanford web authN
+
     # View the specified starting URL
     visit start_url
+    click_through_trust_browser_if_needed # for cardinal key users, straight to 2FA prompt, no login form
 
-    return if page.has_text?(expected_text, wait: Settings.post_authentication_text_timeout)
+    submit_credentials_if_needed
+    click_through_trust_browser_if_needed # for people who hit the login form, 2FA prompt comes after it's submitted
 
-    submit_credentials
-
-    using_wait_time(Settings.timeouts.capybara) do
-      # Once we see this we know the log in succeeded.
-      expect(page).to have_text(expected_text)
+    if page.has_text?(expected_text, wait: Settings.post_authentication_text_timeout)
+      puts " > logged in, found expected post-login String/Regex: #{expected_text}"
+    else
+      puts " ! WARNING: logged in, but no match for expected post-login String/Regex: #{expected_text}"
     end
-  end
-
-  def submit_credentials
-    self.username ||= username_from_config_or_prompt
-    self.password ||= password_from_config_or_prompt
-
-    if page.has_text?('SUNet ID', wait: Settings.post_authentication_text_timeout)
-      fill_in 'SUNet ID', with: username
-      fill_in 'Password', with: password
-      click_button 'Login'
-    end
-
-    click_button 'Yes, trust browser'
   end
 
   def ensure_token
@@ -58,5 +48,30 @@ module AuthenticationHelpers
       puts
       password.strip
     end
+  end
+
+  def ensure_username!
+    self.username ||= username_from_config_or_prompt
+  end
+
+  def ensure_password!
+    self.password ||= password_from_config_or_prompt
+  end
+
+  def submit_credentials_if_needed
+    return unless page.has_text?('SUNet ID', wait: Settings.post_authentication_text_timeout)
+
+    ensure_password!
+    fill_in 'SUNet ID', with: username
+    fill_in 'Password', with: password
+    click_button 'Login'
+  end
+
+  # cardinal key users won't get prompted with login form, but may need to click through this prompt, hence
+  # splitting this method from login form submission
+  def click_through_trust_browser_if_needed
+    return unless page.has_text?('Yes, trust browser', wait: Settings.post_authentication_text_timeout)
+
+    click_button 'Yes, trust browser'
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

* fix a typo
* more robust handling of different login workflow possibilities for different users
* accommodation of slow redirects through duo 2FA service when visiting item show page in argo

commit messages have a bit more detail about the motivation for the changes.

## Was README.md updated if necessary? 🤨

N/A, i think?
