### PR TITLE
authentication fixups, ETD embargo date check

### DIFF
--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -206,9 +206,11 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
     authenticate!(start_url: "#{Settings.argo_url}/view/#{prefixed_druid}",
                   expected_text: 'Embargoed until ')
 
-    # NOTE: temporarily commenting out the specific embargo date check since sometimes this is off by a day
-    # embargo_date = DateTime.now.utc.to_date >> 6
-    # reload_page_until_timeout!(text: "Embargoed until #{embargo_date.to_formatted_s(:long)}")
+    embargo_date = DateTime.now.utc.to_date >> 6
+    embargo_date_plus1 = embargo_date + 1
+    # now + 6 months is sometimes off by a day, maybe something timezone/utc/daylight savings related?
+    embargo_date_regex_str = "[#{embargo_date.to_formatted_s(:long)}|#{embargo_date_plus1.to_formatted_s(:long)}]"
+    reload_page_until_timeout!(text: /Embargoed until #{embargo_date_regex_str}/)
     expect(page).to have_text(dissertation_title)
     apo_element = find_table_cell_following(header_text: 'Admin policy')
     expect(apo_element.first('a')[:href]).to end_with('druid:bx911tp9024') # this is hardcoded in hydra_etd app

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
   let(:user_email) { "#{AuthenticationHelpers.username}@stanford.edu" }
 
   before do
-    authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: 'Dashboard')
+    authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: /Dashboard|Continue your deposit/)
   end
 
   scenario do

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     find_field('Search...').send_keys("\"#{item_title}\"", :enter)
     reload_page_until_timeout!(text: 'v1 Accessioned')
 
-    # give perservation a chance to catch up before we create a new version
+    # give preservation a chance to catch up before we create a new version
     #  since the shelving step does diffs that depend on files being visible in preservation
     sleep 5
 

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -8,16 +8,14 @@ module AuthenticationHelpers
 
     # View the specified starting URL
     visit start_url
+    return if expected_text_found?(expected_text) # short-circuit if we are already authenticated
+
     click_through_trust_browser_if_needed # for cardinal key users, straight to 2FA prompt, no login form
 
     submit_credentials_if_needed
     click_through_trust_browser_if_needed # for people who hit the login form, 2FA prompt comes after it's submitted
 
-    if page.has_text?(expected_text, wait: Settings.timeouts.post_authentication_text)
-      puts " > logged in, found expected post-login String/Regex: #{expected_text}"
-    else
-      puts " ! WARNING: logged in, but no match for expected post-login String/Regex: #{expected_text}"
-    end
+    expected_text_found?(expected_text)
   end
 
   def ensure_token
@@ -31,6 +29,16 @@ module AuthenticationHelpers
   end
 
   private
+
+  def expected_text_found?(expected_text)
+    if page.has_text?(expected_text, wait: Settings.timeouts.post_authentication_text)
+      puts " > logged in, found expected post-login String/Regex: #{expected_text}"
+      true
+    else
+      puts " ! WARNING: logged in, but no match for expected post-login String/Regex: #{expected_text}"
+      false
+    end
+  end
 
   def username_from_config_or_prompt
     Settings.sunet.id || begin

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -4,30 +4,20 @@ module AuthenticationHelpers
   mattr_accessor :username, :password, :token
 
   def authenticate!(start_url:, expected_text:)
+    ensure_username! # sunet is needed by some tests, even if the user doesn't have to enter user/pass for Stanford web authN
+
     # View the specified starting URL
     visit start_url
+    click_through_trust_browser_if_needed # for cardinal key users, straight to 2FA prompt, no login form
 
-    return if page.has_text?(expected_text, wait: Settings.timeouts.post_authentication_text)
+    submit_credentials_if_needed
+    click_through_trust_browser_if_needed # for people who hit the login form, 2FA prompt comes after it's submitted
 
-    submit_credentials
-
-    using_wait_time(Settings.timeouts.capybara) do
-      # Once we see this we know the log in succeeded.
-      expect(page).to have_text(expected_text)
+    if page.has_text?(expected_text, wait: Settings.timeouts.post_authentication_text)
+      puts " > logged in, found expected post-login String/Regex: #{expected_text}"
+    else
+      puts " ! WARNING: logged in, but no match for expected post-login String/Regex: #{expected_text}"
     end
-  end
-
-  def submit_credentials
-    self.username ||= username_from_config_or_prompt
-    self.password ||= password_from_config_or_prompt
-
-    if page.has_text?('SUNet ID', wait: Settings.timeouts.post_authentication_text)
-      fill_in 'SUNet ID', with: username
-      fill_in 'Password', with: password
-      click_button 'Login'
-    end
-
-    click_button 'Yes, trust browser'
   end
 
   def ensure_token
@@ -58,5 +48,30 @@ module AuthenticationHelpers
       puts
       password.strip
     end
+  end
+
+  def ensure_username!
+    self.username ||= username_from_config_or_prompt
+  end
+
+  def ensure_password!
+    self.password ||= password_from_config_or_prompt
+  end
+
+  def submit_credentials_if_needed
+    return unless page.has_text?('SUNet ID', wait: Settings.timeouts.post_authentication_text)
+
+    ensure_password!
+    fill_in 'SUNet ID', with: username
+    fill_in 'Password', with: password
+    click_button 'Login'
+  end
+
+  # cardinal key users won't get prompted with login form, but may need to click through this prompt, hence
+  # splitting this method from login form submission
+  def click_through_trust_browser_if_needed
+    return unless page.has_text?('Yes, trust browser', wait: Settings.timeouts.post_authentication_text)
+
+    click_button 'Yes, trust browser'
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

this rebases my branch from #521 on @mjgiarlo's branch from #517, and rebases it all on current `main`.  some of my changes from #521 evaporate out.

happy to let #517 get merged, and then rebase this.

* typo fix
* slightly more modular prompting for username/password as needed (and if prompting for username, does so before browser launch)
* re-enables check for embargo date, with a bit more looser of a date expectation

a bit more detail in commit messages.

## Was README.md updated if necessary? 🤨

N/A, i think?