### PR TITLE
Click upload

### DIFF
--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
 
     # Work Deposit view
     attach_file('spec/fixtures/sul-logo.png') do
+      find_by_id('work_upload_type_browser').click
       find_button('Choose files').click
     end
     expect(page).to have_text('sul-logo.png')


### PR DESCRIPTION
## Why was this change made? 🤔

Since the upload is no longer selected by default it needs to be clicked before `Choose files` appears on the page. Maybe there's a better way of getting capybara to find the radio button?

## Was README.md updated if necessary? 🤨


