### PR TITLE
Test virtual object creation with an item containing a member order

### DIFF
--- a/spec/features/virtual_object_creation_spec.rb
+++ b/spec/features/virtual_object_creation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Use Argo to create a virtual object with constituent objects' do
     ensure_token
 
     # Create virtual object
-    virtual_object_druid = deposit_object
+    virtual_object_druid = deposit_object(viewing_direction: 'left-to-right')
     puts " *** virtual object druid: #{virtual_object_druid} ***" # useful for debugging
 
     # Create constituent objects

--- a/spec/support/deposit_helpers.rb
+++ b/spec/support/deposit_helpers.rb
@@ -24,7 +24,7 @@ module DepositHelpers
   end
 
   # rubocop:disable Metrics/MethodLength
-  def deposit_object(filenames: [])
+  def deposit_object(filenames: [], **kwargs)
     files_metadata = {}
     grouping_strategy = SdrClient::Deposit::SingleFileGroupingStrategy
     if filenames.any?
@@ -48,7 +48,8 @@ module DepositHelpers
                            file_set_type_strategy:,
                            files: filenames,
                            basepath: 'spec/fixtures',
-                           files_metadata:)
+                           files_metadata:,
+                           **kwargs)
 
     visit "#{start_url}/view/#{object_druid}"
 


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/argo#3945

This commit adds a viewing direction to the object used as the virtual object in the virtual object creation test, in order to make sure objects with an existing member order are correctly virtual object-ified.
