### PR TITLE
add new spec for registering objects with folio_instance_hrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ If you find you need to modify the default window size for either browser---*e.g
 ### Increase Timeout Values
 
 If you are experiencing timeout errors when running tests, you may override the default timeout values by adding `timeouts.capybara`, `timeouts.bulk_action`, and/or `timeouts.workflow` in `config/settings.local.yml` depending on where you see timeouts.
+
+### Folio Integration
+
+Some specs may only work if the environment being tested has Folio enabled.  You can tell the integration tests if folio is enabled in a given environment via the `Settings.folio.enabled` setting.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -45,5 +45,7 @@ gis:
   robots_content_root: '/var/geomdtk/current/stage'
   username: 'lyberadmin'
 
+test_folio_instance_hrid: 'a10065784'
+
 folio:
   enabled: false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -18,3 +18,6 @@ was_registrar:
   jobs_directory: '/was_unaccessioned_data/jobs'
   url: 'https://was-registrar-app-qa.stanford.edu'
   username: 'was'
+
+folio:
+  enabled: true

--- a/spec/features/create_folio_object_spec.rb
+++ b/spec/features/create_folio_object_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Use Argo to create an item object with a folio instance HRID' do
+  let(:random_word) { random_phrase }
+  let(:object_label) { "Object Label for #{random_word}" }
+  let(:start_url) { "#{Settings.argo_url}/registration" }
+  let(:source_id) { "create-obj-folio-instance-hrid-test:#{random_alpha}" }
+  let(:folio_instance_hrid) { Settings.test_folio_instance_hrid }
+  let(:catalog_object_label) { 'The means to prosperity' } # will be pulled from folio
+  let(:folio_instance_hrid_updated) { 'a123' }
+  let(:catalog_object_label_updated) { 'A la francaise' } # the updated label after we change the hrid
+  let(:user_tag) { 'Some : UniqueTagValue' }
+  let(:project) { 'Awesome Folio Project' }
+
+  before do
+    authenticate!(start_url:,
+                  expected_text: 'Register DOR Items')
+  end
+
+  scenario do
+    abort 'SKIPPING: Folio not enabled' unless Settings.folio.enabled
+
+    # fill in registration form
+    select 'integration-testing', from: 'Admin Policy'
+    select 'integration-testing', from: 'Collection'
+    select 'book', from: 'Content Type'
+    fill_in 'Tag', with: user_tag
+    fill_in 'Project Name', with: project
+
+    fill_in 'Source ID', with: source_id
+    fill_in 'Folio Instance HRID', with: folio_instance_hrid
+    fill_in 'Label', with: object_label # will be overwritten and checked below
+
+    click_button 'Register'
+
+    # wait for object to be registered
+    expect(page).to have_text 'Items successfully registered.'
+
+    bare_object_druid = find('table a').text
+    object_druid = "druid:#{bare_object_druid}"
+    puts " *** create folio object spec druid: #{object_druid} ***" # useful for debugging
+
+    visit "#{Settings.argo_url}/view/#{object_druid}"
+
+    # wait for registrationWF to finish
+    reload_page_until_timeout!(text: 'v1 Registered')
+
+    # look for metadata
+    expect(page).to have_text(user_tag)
+    expect(page).to have_text("Project : #{project}")
+    expect(page).to have_text(Settings.test_folio_instance_hrid)
+    expect(page).to have_text(catalog_object_label) # this was pulled from folio, overwriting used entered label
+    expect(page).to have_text("Registered By : #{AuthenticationHelpers.username}")
+
+    # edit folio_instance_hrid
+    click_link 'Manage Folio Instance HRID'
+    fill_in 'catalog_record_id_catalog_record_ids_attributes_0_value', with: folio_instance_hrid_updated
+    click_button 'Update'
+
+    # look for updated hrid and refresh metadata
+    expect(page).to have_text(folio_instance_hrid_updated)
+    click_button 'Manage description'
+    click_link 'Refresh'
+    reload_page_until_timeout!(text: catalog_object_label_updated) # updated label pulled from folio for new HRID
+
+    # look for metadata source facet having an entry of Folio for this druid
+    fill_in 'Search...', with: object_druid
+    click_button 'Search'
+    click_button 'Metadata Source (Multi)'
+    within '#facet-metadata_source_ssim ul.facet-values' do
+      within 'li' do
+        find_link('Folio')
+        find('.facet-count', text: 1)
+      end
+    end
+  end
+end

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'SDR deposit' do
   let(:start_url) { Settings.argo_url }
   let(:source_id) { "testing:#{SecureRandom.uuid}" }
   let(:catkey) { '10065784' }
-  let(:folio_instance_hrid) { 'a10065784' }
+  let(:folio_instance_hrid) { Settings.test_folio_instance_hrid }
 
   before do
     authenticate!(start_url:, expected_text: 'Welcome to Argo!')


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #561 

Add a new spec to verify we can register objects in Argo using a folio_instance_hrid and it pulls the label from Folio.

Note: This will only work if the environment being tested has folio enabled across all apps.  This is currently only true in QA.  This is determined via the setting.

## Was README.md updated if necessary? 🤨

Yes
