### PR TITLE
skip is better than abort (which halts all the test)

### DIFF
--- a/spec/features/create_folio_object_spec.rb
+++ b/spec/features/create_folio_object_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe 'Use Argo to create an item object with a folio instance HRID' do
   let(:project) { 'Awesome Folio Project' }
 
   before do
+    skip("SKIPPING: Folio not enabled in #{ENV.fetch('SDR_ENV')}") unless Settings.folio.enabled
     authenticate!(start_url:,
                   expected_text: 'Register DOR Items')
   end
 
   scenario do
-    abort 'SKIPPING: Folio not enabled' unless Settings.folio.enabled
-
     # fill in registration form
     select 'integration-testing', from: 'Admin Policy'
     select 'integration-testing', from: 'Collection'


### PR DESCRIPTION
## Why was this change made? 🤔

The skipped folio test should use 'skip' and not 'abort' (which seems to stop all the tests).  And better done in the  before block so we don't load the argo reg page first.
