### PR TITLE
default to stage if no SDR_ENV

### DIFF
--- a/spec/features/create_folio_object_spec.rb
+++ b/spec/features/create_folio_object_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Use Argo to create an item object with a folio instance HRID' do
   let(:project) { 'Awesome Folio Project' }
 
   before do
-    skip("SKIPPING: Folio not enabled in #{ENV.fetch('SDR_ENV')}") unless Settings.folio.enabled
+    skip("SKIPPING: Folio not enabled in #{ENV.fetch('SDR_ENV', 'stage')}") unless Settings.folio.enabled
     authenticate!(start_url:,
                   expected_text: 'Register DOR Items')
   end


### PR DESCRIPTION
## Why was this change made? 🤔

If no SDR_ENV is passed, we need this so it defaults to stage as in other test.

Follow on from #565



