### PR TITLE
h2_object_creation: current_url is sometimes slow

### DIFF
--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -96,7 +96,8 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     within '.document-title-heading' do
       click_link
     end
-    bare_druid = page.current_url.split(':').last
+    sleep 1 # sometimes the current_url is not updated quickly enough
+    bare_druid = page.current_url.split('druid:').last
     puts " *** h2 object creation druid: #{bare_druid} ***" # useful for debugging
     reload_page_until_timeout!(text: 'v1 Accessioned')
 


### PR DESCRIPTION
## Why was this change made? 🤔

h2_object_creation test kept failing for me for two reasons:
1.  the current_url it was parsing for the druid was the search url, not the show url for an object.  This is a fix for the problem.
2. it gets hung up on the shelve step because the content isn't in the right place yet.  For that I was manually rerunning the shelve step in another window.  Sidekiq can't do it because it ran the job and it failed.   I did not fix that problem.

## Was README.md updated if necessary? 🤨


