### PR TITLE
update Settings.goobi.url to point to newly built goobi stage server

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,7 +37,7 @@ sunet:
 
 # the URL and username/password used to login to goobi (applicable to stage only)
 goobi:
-  url: https://goobi-stage.stanford.edu/goobi
+  url: https://goobi-stage-a.stanford.edu/goobi
   username: ~
   password: ~
 


### PR DESCRIPTION
## Why was this change made? 🤔

goobi stage was rebuilt to use ubuntu as its OS, and now lives at a slightly different hostname

## Was README.md updated if necessary? 🤨

n/a