### PR TITLE
PageHelpers.reload_page_until_timeout_with_wf_step_retry! method added

### DIFF
--- a/spec/features/item_creation_no_files_spec.rb
+++ b/spec/features/item_creation_no_files_spec.rb
@@ -49,8 +49,11 @@ RSpec.describe 'Use Argo to create an item object without any files' do
     expect(page).to have_text("Project : #{project}")
     expect(page).to have_text("Registered By : #{AuthenticationHelpers.username}")
 
-    # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v1 Accessioned')
+    # wait for accessioningWF to finish; retry if Version mismatch on sdr-ingest-transfer
+    reload_page_until_timeout_with_wf_step_retry!(expected_text: 'v1 Accessioned',
+                                                  workflow: 'accessionWF',
+                                                  workflow_retry_text: 'Version mismatch',
+                                                  retry_wait: 2)
 
     # open a new version
     click_link 'Unlock to make changes to this object'
@@ -71,7 +74,10 @@ RSpec.describe 'Use Argo to create an item object without any files' do
     expect(page).to have_text('closing version for integration testing')
     page.refresh # solves problem of close version modal re-appearing
 
-    # wait for accessioningWF to finish
-    reload_page_until_timeout!(text: 'v2 Accessioned')
+    # wait for accessioningWF to finish; retry if Version mismatch on sdr-ingest-transfer
+    reload_page_until_timeout_with_wf_step_retry!(expected_text: 'v2 Accessioned',
+                                                  workflow: 'accessionWF',
+                                                  workflow_retry_text: 'Version mismatch',
+                                                  retry_wait: 2)
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,14 +1,40 @@
 # frozen_string_literal: true
 
 module PageHelpers
-  def reload_page_until_timeout!(text: '', check_wf_error: true)
+  def reload_page_until_timeout!(text: '')
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
         break if block_given? ? yield : page.has_text?(text, wait: 1)
 
         # Check for workflow errors and bail out early. There is no recovering
         # from a workflow error. This selector is found on the Argo item page.
-        expect(page).not_to have_css('.alert-danger', wait: 0) if check_wf_error
+        expect(page).not_to have_css('.alert-danger', wait: 0)
+
+        page.refresh
+      end
+    end
+  end
+
+  # Some workflow steps fail due to race conditions or other temporary annoyances.
+  # This method provides a way to retry a workflow step if the workflow fails with a specific error message
+  def reload_page_until_timeout_with_wf_step_retry!(expected_text: '',
+                                                    workflow: 'accessionWF',
+                                                    workflow_retry_text: '',
+                                                    retry_wait: 5)
+    Timeout.timeout(Settings.timeouts.workflow) do
+      loop do
+        break if block_given? ? yield : page.has_text?(expected_text, wait: 1)
+
+        if page.has_css?('.alert-danger', wait: 0) && page.has_text?(workflow_retry_text)
+          click_link workflow
+          select 'Rerun', from: 'status'
+          confirm_message = 'You have selected to manually change the status. '
+          confirm_message += 'This could result in processing errors. Are you sure you want to proceed?'
+          accept_confirm(confirm_message) do
+            click_button 'Save'
+          end
+          sleep retry_wait
+        end
 
         page.refresh
       end


### PR DESCRIPTION
## Why was this change made? 🤔

in PR #566, Peter added code to rerun a workflow step if needed.  This makes that approach into something clearer (if verbose) and puts it to use in an additional test.   Both tests using this new method failed for me consistently at the same workflow steps.


## Was README.md updated if necessary? 🤨


