### PR TITLE
Bump sleeps in pre-assembly specs to allow them to pass

### DIFF
--- a/spec/features/preassembly_hfs_accessioning_spec.rb
+++ b/spec/features/preassembly_hfs_accessioning_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe 'Create and re-accession object with hierarchical files via Pre-a
 
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('file') # filled in by accessioning
 
-    sleep 10 # let's wait a bit before trying the re-accession to avoid a possible race condition
+    sleep 20 # let's wait a bit before trying the re-accession to avoid a possible race condition
 
     ### Re-accession
 

--- a/spec/features/preassembly_image_accessioning_spec.rb
+++ b/spec/features/preassembly_image_accessioning_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
 
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('image') # filled in by accessioning
 
-    sleep 10 # let's wait a bit before trying the re-accession to avoid a possible race condition
+    sleep 20 # let's wait a bit before trying the re-accession to avoid a possible race condition
 
     ### Re-accession
 


### PR DESCRIPTION
## Why was this change made? 🤔

To help the pre-assembly tests pass in stage. They were consistently failing with the prior sleep values, now that Ruby 3.2 is deployed everywhere. They were the only tests that failed.

I'm not sure how much to be concerned about this, given that Andrew's testing in stage has not reproduced this error condition. He's tried with a batch of small files and a batch of large files, and neither wound up in this situation.

## Was README.md updated if necessary? 🤨

No.
