### PR TITLE
explicitly add websocket as a gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,4 @@ gem 'rubyXL' # for updating Excel spreadsheets
 gem 'sdr-client', '~> 2.0'
 gem 'selenium-webdriver'
 gem 'webdrivers'
+gem 'websocket' # required by selenium-webdrivers; a ruby upgrade somehow obscured this dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -254,6 +255,7 @@ DEPENDENCIES
   sdr-client (~> 2.0)
   selenium-webdriver
   webdrivers
+  websocket
 
 BUNDLED WITH
    2.4.13


### PR DESCRIPTION
## Why was this change made? 🤔

I couldn't run the integration tests when I upgraded to ruby 3.2.2;  they failed with this error:

```
$ bx rspec

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require 'selenium-webdriver'

LoadError:
  cannot load such file -- websocket
# ./spec/spec_helper.rb:11:in `<top (required)>
```

I could run rspec with ruby 3.1.2, but not with ruby 3.2.2.   when I added the `websocket` gem on the command line for ruby 3.2.2, I could run rspec with ruby 3.2.2.   Hence, my adding it to the Gemfile.  It may or may not fix the problem for the next person upgrading to ruby 3.2.2.


I also note https://github.com/titusfortner/webdrivers/blob/main/README.md?plain=1#L8-L12, which may imply we won't need the webdrivers gem much longer (?)  ... which is not to say we wouldn't need websockets.

## Was README.md updated if necessary? 🤨


