### PR TITLE
fix label text used to find Metadata Source facet button in test for Argo item creation with folio HRID

### DIFF
--- a/spec/features/item_creation_with_folio_hrid_spec.rb
+++ b/spec/features/item_creation_with_folio_hrid_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Use Argo to create an item object with a folio instance HRID' do
     # look for metadata source facet having an entry of Folio for this druid
     fill_in 'Search...', with: object_druid
     click_button 'Search'
-    click_button 'Metadata Source (Multi)'
+    click_button 'Metadata Source'
     within '#facet-metadata_source_ssim ul.facet-values' do
       within 'li' do
         find_link('Folio')


### PR DESCRIPTION
looks like the relevant argo change was made here: https://github.com/sul-dlss/argo/commit/36bacbe475d45f73c791816d20ffbf6578e08352

## Why was this change made? 🤔

keep the test suite up to date.  discovered when running against QA after deploying this week's dep updates.

## Was README.md updated if necessary? 🤨

nope