### PR TITLE
update integration tests for pre-assembly changes

### DIFF
--- a/spec/features/preassembly_hfs_accessioning_spec.rb
+++ b/spec/features/preassembly_hfs_accessioning_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Create and re-accession object with hierarchical files via Pre-a
     select 'Pre Assembly Run', from: 'Job type'
     fill_in 'Staging location', with: preassembly_hfs_bundle_dir
     select 'File', from: 'Content structure'
-    select 'Default', from: 'Content metadata creation'
+    select 'Default', from: 'Processing configuration'
 
     click_button 'Submit'
 

--- a/spec/features/preassembly_image_accessioning_spec.rb
+++ b/spec/features/preassembly_image_accessioning_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     fill_in 'Project name', with: random_project_name
     select 'Pre Assembly Run', from: 'Job type'
     fill_in 'Staging location', with: preassembly_bundle_dir
-    select 'Filename', from: 'Content metadata creation'
+    select 'Group by filename', from: 'Processing configuration'
 
     click_button 'Submit'
 


### PR DESCRIPTION
## Why was this change made? 🤔

Because changes in sul-dlss/pre-assembly#1180 change the UI and we need to update the integration test to match.

~~HOLD until pre-assembly change is merged~~

