### PR TITLE
Remove transitional README block now that we are on folio

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,3 @@ If you find you need to modify the default window size for either browser---*e.g
 
 If you are experiencing timeout errors when running tests, you may override the default timeout values by adding `timeouts.capybara`, `timeouts.bulk_action`, and/or `timeouts.workflow` in `config/settings.local.yml` depending on where you see timeouts.
 
-### Folio Integration
-
-Some specs may only work if the environment being tested has Folio enabled.  You can tell the integration tests if folio is enabled in a given environment via the `Settings.folio.enabled` setting.

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -18,6 +18,3 @@ was_registrar:
   jobs_directory: '/was_unaccessioned_data/jobs'
   url: 'https://was-registrar-app-qa.stanford.edu'
   username: 'was'
-
-folio:
-  enabled: true


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #623 

## Was README.md updated if necessary? 🤨


