### PR TITLE
bulk_tags_edit_spec: update tag field

### DIFF
--- a/spec/features/bulk_tags_edit_spec.rb
+++ b/spec/features/bulk_tags_edit_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Use Argo to edit administrative tags in bulk' do
-  let(:start_url) { "#{Settings.argo_url}/catalog?f%5Bexploded_tag_ssim%5D%5B%5D=Registered+By" }
+  let(:start_url) { "#{Settings.argo_url}/catalog?f%5Bexploded_nonproject_tag_ssim%5D%5B%5D=Registered+By" }
   let(:export_tag_description) { random_phrase }
   let(:import_tag_description) { random_phrase }
   let(:number_of_druids) { 3 }


### PR DESCRIPTION
## Why was this change made? 🤔

`exploded_tag_ssim` is going away in PR sul-dlss/dor_indexing_app/issues/1025

## Tested

Ran this updated test against stage and it passed.

