### PR TITLE
revert some click_link_or_button changes back to click_button

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -487,8 +487,6 @@ Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
   Enabled: true
 Style/YAMLFileRead: # new in 1.53
   Enabled: true
-Capybara/ClickLinkOrButtonStyle: # new in 2.19
-  Enabled: true
 Capybara/RSpec/HaveSelector: # new in 2.19
   Enabled: true
 Capybara/RSpec/PredicateMatcher: # new in 2.19
@@ -509,3 +507,16 @@ RSpec/SpecFilePathSuffix: # new in 2.24
   Enabled: true
 RSpec/Rails/NegationBeValid: # new in 2.23
   Enabled: true
+
+# We've encountered cases where we have a link and a button in the same page with the same text.
+# As of this rule's disabling (Jan 2024), the only instances we've seen like that are for
+# the "Register" button on the Argo registration form (there's a nav header link with the same
+# text that leads to the form), and the "Search" button on the Argo view page (afaict the links
+# with the same title are not visible, but may be to screen readers).  If click_link_or_button
+# is used in those cases, we see tests fail with errors like:
+# Ambiguous match, found 2 elements matching visible link or button "Register"
+#
+# Perhaps something to tighten up later, see:
+# https://github.com/sul-dlss/infrastructure-integration-test/pull/663 and https://github.com/sul-dlss/argo/issues/4304
+Capybara/ClickLinkOrButtonStyle: # new in 2.19
+  Enabled: false

--- a/spec/features/access_indexing_spec.rb
+++ b/spec/features/access_indexing_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Argo rights changes result in correct Access Rights facet value'
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'
@@ -73,7 +73,7 @@ end
 
 def find_access_rights_single_facet_value(druid, facet_value)
   fill_in 'Search...', with: druid
-  click_link_or_button 'Search'
+  click_button 'Search'
   click_link_or_button('Access Rights')
 
   within '#facet-rights_descriptions_ssim ul.facet-values' do

--- a/spec/features/apo_creation_spec.rb
+++ b/spec/features/apo_creation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Use Argo to create an APO and verify new objects inherit its rig
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'

--- a/spec/features/etd_creation_spec.rb
+++ b/spec/features/etd_creation_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
     # test Embargo UI and indexing before an item is fully accessioned
     # check Argo facet field with 6 month embargo
     fill_in 'Search...', with: prefixed_druid
-    click_link_or_button 'Search'
+    click_button 'Search'
     click_link_or_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do
       expect(page).to have_no_text('up to 7 days', wait: 1)
@@ -263,7 +263,7 @@ RSpec.describe 'Create a new ETD with embargo, and then update the embargo date'
 
     # check Argo facet field with 3 day embargo
     fill_in 'Search...', with: prefixed_druid
-    click_link_or_button 'Search'
+    click_button 'Search'
     click_link_or_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do
       find_link('up to 7 days')

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'

--- a/spec/features/goobi_accessioning_spec.rb
+++ b/spec/features/goobi_accessioning_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Create and accession object via Goobi', if: $sdr_env == 'stage' 
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
 
     # check Argo facet field with 3 day embargo
     fill_in 'Search...', with: bare_druid
-    click_link_or_button 'Search'
+    click_button 'Search'
     reload_page_until_timeout!(text: 'Embargo Release Date')
     click_link_or_button('Embargo Release Date')
     within '#facet-embargo_release_date ul.facet-values' do

--- a/spec/features/item_creation_no_files_or_collection_spec.rb
+++ b/spec/features/item_creation_no_files_or_collection_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Use Argo to create an item object without any files and no colle
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'

--- a/spec/features/item_creation_with_folio_hrid_spec.rb
+++ b/spec/features/item_creation_with_folio_hrid_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Use Argo to create an item object with a folio instance HRID' do
     fill_in 'Folio Instance HRID', with: folio_instance_hrid
     fill_in 'Label', with: object_label # will be overwritten and checked below
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'
@@ -63,7 +63,7 @@ RSpec.describe 'Use Argo to create an item object with a folio instance HRID' do
 
     # look for metadata source facet having an entry of Folio for this druid
     fill_in 'Search...', with: object_druid
-    click_link_or_button 'Search'
+    click_button 'Search'
     click_link_or_button 'Metadata Source'
     within '#facet-metadata_source_ssim ul.facet-values' do
       within 'li' do

--- a/spec/features/preassembly_hfs_accessioning_spec.rb
+++ b/spec/features/preassembly_hfs_accessioning_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Create and re-accession object with hierarchical files via Pre-a
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'

--- a/spec/features/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly_reaccessioning_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     fill_in 'Source ID', with: "#{source_id}-#{random_alpha}"
     fill_in 'Label', with: object_label
 
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     # wait for object to be registered
     expect(page).to have_text 'Items successfully registered.'

--- a/spec/features/web_archive_accessioning_spec.rb
+++ b/spec/features/web_archive_accessioning_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     fill_in 'Source ID', with: "seed-#{source_id}"
     fill_in 'Label', with: url_in_wayback
     fill_in 'Tags', with: 'webarchive : seed'
-    click_link_or_button 'Register'
+    click_button 'Register'
 
     expect(page).to have_text 'Items successfully registered.'
 


### PR DESCRIPTION
## Why was this change made? 🤔

The former is ambiguous for argo object registration and search.

I like the spirit of the rubocop suggestion, but for an integration test of other existing codebases, it seems a bit presumptuous.  So, I went with inline exceptions and a comment, since it might be nice to have rubocop nudge us towards better page element disambiguation when writing new app code (which seems like the driver for most, though not all, of our new integration tests?).  But I'm totally happy to just disable the rubocop rule with an explanation in `.rubocop.yml`, and get rid of the inline comments and exceptions.

Also, for the cases that make a difference in Argo, I'm guessing that this isn't a huge deal: I doubt that sighted users will confuse the "Register" nav link at the top of the page with the "Register" button that submits the form that the aforementioned link takes you to.  And I'm guessing (though grain of salt since this isn't an area of expertise) that visually impaired users who are using screen readers will be able to easily tell from the context and experience with other pages that the nav link and the button have different purposes.  Maybe the "Search" thing will be trickier, harder for me to judge that, since the "Search" links that got confused with the "Search" button didn't seem to be visible to me in the Argo show page.

## Was README.md updated if necessary? 🤨

n/a
