### PR TITLE
Prefer current `sdr_client` require to outdated `sdr-client` one

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'faker'
 require 'io/console'
 require 'pry-byebug'
 require 'rubyXL'
-require 'sdr-client'
+require 'sdr_client'
 require 'selenium-webdriver'
 require 'webdrivers'
 


### PR DESCRIPTION
# Why was this change made?

This commit does not make any functional changes since the sdr-client gem allows requires of both, at the moment at the least. Ran the SDR deposit spec to confirm.

# Was README.md updated if necessary?

N/A
