### PR TITLE
H2: click through the terms of deposit modal when it's presented

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,7 @@ timeouts:  # in seconds
   workflow: 300
   bulk_action: 200
   post_authentication_text: 5
+  h2_terms_modal_wait: 5 # should show quickly, so can be much shorter than default wait time
   events:
     poll_for: 240
     poll_interval: 2

--- a/spec/features/h2_globus_creation_spec.rb
+++ b/spec/features/h2_globus_creation_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     select 'CC0-1.0', from: 'collection_required_license'
 
     click_link_or_button 'Deposit'
+    click_through_terms_of_deposit_modal
     expect(page).to have_text(collection_title)
     expect(page).to have_text('+ Deposit to this collection')
 
@@ -65,6 +66,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     click_link_or_button 'Edit or Deposit'
     check('Check this box once all your files have completed uploading to Globus.')
     click_link_or_button 'Deposit'
+    click_through_terms_of_deposit_modal
 
     expect(page).to have_text 'You have successfully deposited your work'
     click_link_or_button 'Return to dashboard'

--- a/spec/features/h2_globus_creation_spec.rb
+++ b/spec/features/h2_globus_creation_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: /Dashboard|Continue your deposit/)
   end
 
+  # note! you likely want to use `click_deposit_and_handle_terms_modal` for deposit
+  # form submission (instead of just `click_link_or_button 'Deposit'`), since the modal
+  # may pop up on any attempt to deposit.
   scenario do
     # remove modal for deposit in progress, if present, waiting a bit for some rendering
     click_link_or_button 'No' if page.has_text?('Continue your deposit', wait: Settings.timeouts.post_authentication_text)
@@ -28,8 +31,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     # Select license
     select 'CC0-1.0', from: 'collection_required_license'
 
-    click_link_or_button 'Deposit'
-    click_through_terms_of_deposit_modal
+    click_deposit_and_handle_terms_modal
     expect(page).to have_text(collection_title)
     expect(page).to have_text('+ Deposit to this collection')
 
@@ -65,8 +67,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     expect(page).to have_text('Draft - Not deposited')
     click_link_or_button 'Edit or Deposit'
     check('Check this box once all your files have completed uploading to Globus.')
-    click_link_or_button 'Deposit'
-    click_through_terms_of_deposit_modal
+    click_deposit_and_handle_terms_modal
 
     expect(page).to have_text 'You have successfully deposited your work'
     click_link_or_button 'Return to dashboard'

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     end
 
     click_link_or_button 'Deposit'
+    click_through_terms_of_deposit_modal
+
     expect(page).to have_text(collection_title)
     expect(page).to have_text('+ Deposit to this collection')
 
@@ -111,6 +113,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     fill_in 'What\'s changing?', with: 'abstract'
     fill_in 'Abstract', with: "A changed abstract for #{collection_title} logo"
     click_link_or_button 'Deposit'
+    click_through_terms_of_deposit_modal
 
     expect(page).to have_text 'You have successfully deposited your work'
 

--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     authenticate!(start_url: "#{Settings.h2_url}/dashboard", expected_text: /Dashboard|Continue your deposit/)
   end
 
+  # note! you likely want to use `click_deposit_and_handle_terms_modal` for deposit
+  # form submission (instead of just `click_link_or_button 'Deposit'`), since the modal
+  # may pop up on any attempt to deposit.
   scenario do
     # remove modal for deposit in progress, if present, waiting a bit for some rendering
     click_link_or_button 'No' if page.has_text?('Continue your deposit', wait: Settings.timeouts.post_authentication_text)
@@ -36,8 +39,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
       click_link_or_button 'Add'
     end
 
-    click_link_or_button 'Deposit'
-    click_through_terms_of_deposit_modal
+    click_deposit_and_handle_terms_modal
 
     expect(page).to have_text(collection_title)
     expect(page).to have_text('+ Deposit to this collection')
@@ -112,8 +114,7 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     click_link_or_button "Edit #{item_title}"
     fill_in 'What\'s changing?', with: 'abstract'
     fill_in 'Abstract', with: "A changed abstract for #{collection_title} logo"
-    click_link_or_button 'Deposit'
-    click_through_terms_of_deposit_modal
+    click_deposit_and_handle_terms_modal
 
     expect(page).to have_text 'You have successfully deposited your work'
 

--- a/spec/support/h2_helpers.rb
+++ b/spec/support/h2_helpers.rb
@@ -2,6 +2,14 @@
 
 # This module helps with common actions in the self deposit app (H2)
 module H2Helpers
+  # all-in-one convenience method for submitting the deposit form and
+  # handling the modal if one is shown
+  def click_deposit_and_handle_terms_modal
+    click_link_or_button 'Deposit'
+    click_through_terms_of_deposit_modal
+  end
+
+  # if a terms of deposit modal is showing, click through it, otherwise do nothing
   def click_through_terms_of_deposit_modal
     return unless terms_of_deposit_modal_showing?
 
@@ -11,6 +19,8 @@ module H2Helpers
   end
 
   def terms_of_deposit_modal_showing?
+    # a bit fragile/un-user-like to use a CSS selector, but the alternative would be
+    # to use very specific substrings from the terms, which also feels fragile.
     return false unless page.has_css?('div.modal', visible: true, wait: modal_selector_wait)
 
     within('div.modal') do

--- a/spec/support/h2_helpers.rb
+++ b/spec/support/h2_helpers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This module helps with common actions in the self deposit app (H2)
+module H2Helpers
+  def click_through_terms_of_deposit_modal
+    return unless terms_of_deposit_modal_showing?
+
+    puts 'clicking through Terms of Deposit modal...'
+    click_close_then_click_deposit
+    puts '...clicked through Terms of Deposit modal'
+  end
+
+  def terms_of_deposit_modal_showing?
+    return false unless page.has_css?('div.modal', visible: true, wait: modal_selector_wait)
+
+    within('div.modal') do
+      return page.has_text?(:visible, 'Terms of Deposit', wait: modal_selector_wait) &&
+             page.has_button?('Close', wait: modal_selector_wait)
+    end
+  end
+
+  def click_close_then_click_deposit
+    find_button('Close').click # for some reason this works where click_link_or_button('Close') does not :shrug:
+    sleep 2 # modal can take a moment or two to go away
+    click_button 'Deposit'
+    sleep 2 # form can take a moment or two to submit
+  end
+
+  def modal_selector_wait
+    Settings.timeouts.h2_terms_modal_wait
+  end
+end
+
+RSpec.configure { |config| config.include H2Helpers }


### PR DESCRIPTION
## Why was this change made? 🤔

I was getting presented with a terms of deposit modal in the H2 tests modified here, and since the tests didn't handle it, I had to babysit them and click through manually to get them to pass.  This PR should hopefully alleviate the babysitting.

_**Example of the modal:**_
<img width="1428" alt="Screenshot 2024-01-09 at 11 49 31 AM" src="https://github.com/sul-dlss/infrastructure-integration-test/assets/7741604/1e0df5cf-d495-45d5-b02d-76a3ec9b60fb">

Here's an example screencast of me successfully letting the two modified tests run.  It's a bit long, but you can see the terms modal flit by at 0:10 and 0:25 for one test; and 1:04 and 1:46 for the other.  It was 65 MB over github's 100 MB limit, hence this drive link: https://drive.google.com/file/d/1n2EOWYXZykIJJZ2x1FoydiivouSQyNiv/view?usp=drive_link

_**screenshot of the test output:**_

<img width="878" alt="Screenshot 2024-01-11 at 1 19 18 PM" src="https://github.com/sul-dlss/infrastructure-integration-test/assets/7741604/50af6af8-6ebc-4f27-94e6-3f2d9896ab42">


## Was README.md updated if necessary? 🤨


