### PR TITLE
select geo for geo integration spec

### DIFF
--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     # register new GIS object
     select apo_name, from: 'Admin Policy'
     select collection_name, from: 'Collection'
-    select 'file', from: 'Content Type'
+    select 'geo', from: 'Content Type'
     fill_in 'Project Name', with: project_name
     fill_in 'Source ID', with: source_id
     fill_in 'Label', with: object_label


### PR DESCRIPTION
## Why was this change made? 🤔

We should consider selecting 'geo' as the content type when registering the object in Argo for the geo integration test.  Currently it works fine selecting 'file' as a later step in the process will switch it to geo, but we believe the only reason this was necessary was because geo was not always an option when registering in Argo.  It is now, and seems less confusing to just select that from the beginning.

Tested on stage and the test still works.
