### PR TITLE
[HOLD] update expected filenames for GIS

### DIFF
--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     # look for expected files produced by GIS workflows
     files = all('tr.file')
     expect(files.size).to eq 3
-    expect(files[0].text).to match(%r{data.zip application/zip 5\d.\d KB})
-    expect(files[1].text).to match(%r{data_EPSG_4326.zip application/zip 2\d KB})
+    expect(files[0].text).to match(%r{#{bare_druid}.zip application/zip 5\d.\d KB})
+    expect(files[1].text).to match(%r{#{bare_druid}_normalized.zip application/zip 2\d KB})
     expect(files[2].text).to match(%r{preview.jpg image/jpeg 2\d.\d KB})
 
     # verify that the content type is "geo"

--- a/spec/features/preassembly_gis_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_accessioning_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     # look for expected files produced by GIS workflows
     files = all('tr.file')
     expect(files.size).to eq 3
-    expect(files[0].text).to match(%r{data.zip application/zip 5\d.\d KB})
-    expect(files[1].text).to match(%r{data_EPSG_4326.zip application/zip 2\d KB})
+    expect(files[0].text).to match(%r{#{bare_druid}.zip application/zip 5\d.\d KB})
+    expect(files[1].text).to match(%r{#{bare_druid}_normalized.zip application/zip 2\d KB})
     expect(files[2].text).to match(%r{preview.jpg image/jpeg 2\d.\d KB})
 
     # verify that the content type is "geo"


### PR DESCRIPTION
## Why was this change made? 🤔

Goes with https://github.com/sul-dlss/gis-robot-suite/pull/742

If we rename the data.zip and normalized ZIP filenames in the gis robots, we need to update the integration tests to look for them.

[HOLD] until/if https://github.com/sul-dlss/gis-robot-suite/pull/742 is merged

Verified test pass with new robot change deployed to stage.