### PR TITLE
gis test: look for desired text

### DIFF
--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -60,9 +60,11 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
                                                   retry_wait: 5) do |page|
       click_link_or_button 'Reindex'
       sleep 5
-      !page.has_text?('Error: extract-boundingbox')
+      # verify the gisAssemblyWF workflow completes
+      page.has_selector?('#workflow-details-status-gisAssemblyWF', text: 'completed', wait: 1)
     end
-    # verify the gisAssemblyWF workflow completes
+
+    # (re?)verify the gisAssemblyWF workflow completes
     reload_page_until_timeout! do
       page.has_selector?('#workflow-details-status-gisAssemblyWF', text: 'completed', wait: 1)
     end


### PR DESCRIPTION
## Why was this change made? 🤔

test was failing because it takes a long time to assert that text is NOT on a page.  It passed with this change (after failing 3 times) and it also passed a LOT faster.

