### PR TITLE
Check for shelved GIS XML metadata

### DIFF
--- a/spec/features/preassembly_gis_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_accessioning_spec.rb
@@ -120,10 +120,14 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
 
     # look for expected files produced by GIS workflows
     files = all('tr.file')
-    expect(files.size).to eq 3
+    expect(files.size).to eq 7
     expect(files[0].text).to match(%r{data.zip application/zip 5\d.\d KB})
     expect(files[1].text).to match(%r{data_EPSG_4326.zip application/zip 2\d KB})
     expect(files[2].text).to match(%r{preview.jpg image/jpeg 2\d.\d KB})
+    expect(files[3].text).to match(%r{AirMonitoringStations.shp.xml application/xml 6\d.\d KB})
+    expect(files[4].text).to match(%r{AirMonitoringStations-iso19139.xml application/xml 2\d.\d KB})
+    expect(files[5].text).to match(%r{AirMonitoringStations-iso19110.xml application/xml 1\d.\d KB})
+    expect(files[6].text).to match(%r{AirMonitoringStations-fgdc.xml application/xml 5.\d+ KB})
 
     # verify that the content type is "geo"
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('geo')


### PR DESCRIPTION
## Why was this change made? 🤔

follow-on to https://github.com/sul-dlss/infrastructure-integration-test/pull/684/

implements same expectation update as `spec/features/gis_accessioning_spec.rb`, but in `preassembly_gis_accessioning_spec.rb`


## Was README.md updated if necessary? 🤨


