### PR TITLE
verify gis objects make it to Earthworks

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,3 +54,5 @@ preassembly:
   bundle_directory: '/dor/staging/integration-tests/files-reaccessioning-test'
   hfs_bundle_directory: '/dor/staging/integration-tests/hierarchical-file-test'
   gis_bundle_directory: '/dor/staging/integration-tests/gis-test'
+
+earthworks_url: 'https://earthworks.stanford.edu/catalog'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,4 +55,4 @@ preassembly:
   hfs_bundle_directory: '/dor/staging/integration-tests/hierarchical-file-test'
   gis_bundle_directory: '/dor/staging/integration-tests/gis-test'
 
-earthworks_url: 'https://earthworks.stanford.edu/catalog'
+earthworks_url: 'https://earthworks-stage.stanford.edu/catalog'

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -8,7 +8,6 @@ preassembly:
   url: 'https://sul-preassembly-stage.stanford.edu'
 sdrapi_url: 'https://sdr-api-stage.stanford.edu'
 was_playback_url: 'https://swap-stage.stanford.edu'
-earthworks_url: 'https://earthworks-stage.stanford.edu/catalog'
 was_registrar:
   host: 'was-registrar-app-stage.stanford.edu'
   jobs_directory: '/was_unaccessioned_data/jobs'

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -8,6 +8,7 @@ preassembly:
   url: 'https://sul-preassembly-stage.stanford.edu'
 sdrapi_url: 'https://sdr-api-stage.stanford.edu'
 was_playback_url: 'https://swap-stage.stanford.edu'
+earthworks_url: 'https://earthworks-stage.stanford.edu/catalog'
 was_registrar:
   host: 'was-registrar-app-stage.stanford.edu'
   jobs_directory: '/was_unaccessioned_data/jobs'

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     # verify that the content type is "geo"
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('geo')
 
+    # release to Earthworks
+    click_link_or_button 'Manage release'
+    select 'Earthworks', from: 'to'
+    click_link_or_button('Submit')
+    expect(page).to have_text('Release object job was successfully created.')
+
+    # pause for a couple seconds for release to happen
+    sleep 2
+
     # This section confirms the object has been published to PURL
     # wait for the PURL name to be published by checking for collection name and check for bits of expected metadata
     expect_text_on_purl_page(druid:, text: collection_name)
@@ -110,21 +119,6 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     expect(page).to have_text('Cartographic dataset') # genre
     # TODO: Add additional checks for GIS embed delivery on PURL?
     #  May rely on reloading geoserver layers in geoserver UI and existence of qa/stage geoservers and other complications
-
-    # back to argo detail page
-    visit "#{Settings.argo_url}/view/#{druid}"
-
-    # release to Earthworks
-    click_link_or_button 'Manage release'
-    select 'Earthworks', from: 'to'
-    click_link_or_button('Submit')
-    expect(page).to have_text('Release object job was successfully created.')
-
-    # pause for a couple seconds for release to happen
-    sleep 2
-
-    # back to purl page
-    visit "#{Settings.purl_url}/#{bare_druid}"
 
     # click Earthworks link and verify it was released
     click_link_or_button 'View in EarthWorks'

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -123,8 +123,11 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     # pause for a couple seconds for release to happen
     sleep 2
 
-    # go to Earthworks and verify it was released
-    visit "#{Settings.earthworks_url}/stanford-#{bare_druid}"
+    # back to purl page
+    visit "#{Settings.purl_url}/#{bare_druid}"
+
+    # click Earthworks link and verify it was released
+    click_link_or_button 'View in EarthWorks'
     reload_page_until_timeout!(text: 'Air Monitoring Stations: California, 2001-2003')
   end
 end

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     expect_text_on_purl_page(druid:, text: collection_name)
     expect_link_on_purl_page(druid:,
                              text: 'View in EarthWorks',
-                             href: "https://earthworks.stanford.edu/catalog/stanford-#{bare_druid}")
+                             href: "#{Settings.earthworks_url}/stanford-#{bare_druid}")
     expect_text_on_purl_page(druid:, text: 'This point shapefile represents all air monitoring stations active in ' \
                                            'California from 2001 until 2003')
     expect(page).to have_no_text(object_label) # the original object label has been replaced
@@ -108,8 +108,23 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     expect(page).to have_text('EPSG::3310') # form for native projection
     expect(page).to have_text('Geospatial data') # genre
     expect(page).to have_text('Cartographic dataset') # genre
-    expect(page).to have_link('View in EarthWorks') # link to Earthworks
     # TODO: Add additional checks for GIS embed delivery on PURL?
     #  May rely on reloading geoserver layers in geoserver UI and existence of qa/stage geoservers and other complications
+
+    # back to argo detail page
+    visit "#{Settings.argo_url}/view/#{druid}"
+
+    # release to Earthworks
+    click_link_or_button 'Manage release'
+    select 'Earthworks', from: 'to'
+    click_link_or_button('Submit')
+    expect(page).to have_text('Release object job was successfully created.')
+
+    # pause for a couple seconds for release to happen
+    sleep 2
+
+    # go to Earthworks and verify it was released
+    visit "#{Settings.earthworks_url}/stanford-#{bare_druid}"
+    reload_page_until_timeout!(text: 'Air Monitoring Stations: California, 2001-2003')
   end
 end

--- a/spec/features/preassembly_gis_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_accessioning_spec.rb
@@ -162,8 +162,11 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     # pause for a couple seconds for release to happen
     sleep 2
 
-    # go to Earthworks and verify it was released
-    visit "#{Settings.earthworks_url}/stanford-#{bare_druid}"
+    # back to purl page
+    visit "#{Settings.purl_url}/#{bare_druid}"
+
+    # click Earthworks link and verify it was released
+    click_link_or_button 'View in EarthWorks'
     reload_page_until_timeout!(text: 'Air Monitoring Stations: California, 2001-2003')
   end
 end

--- a/spec/features/preassembly_gis_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_accessioning_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     expect_text_on_purl_page(druid:, text: collection_name)
     expect_link_on_purl_page(druid:,
                              text: 'View in EarthWorks',
-                             href: "https://earthworks.stanford.edu/catalog/stanford-#{bare_druid}")
+                             href: "#{Settings.earthworks_url}/stanford-#{bare_druid}")
     expect_text_on_purl_page(druid:, text: 'This point shapefile represents all air monitoring stations active in ' \
                                            'California from 2001 until 2003')
     expect(page).to have_no_text(object_label) # the original object label has been replaced
@@ -149,6 +149,21 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     expect(page).to have_text('Scale not given ; EPSG::3310') # map data
     expect(page).to have_text('Geospatial data') # genre
     expect(page).to have_text('Cartographic dataset') # genre
-    expect(page).to have_link('View in EarthWorks') # link to Earthworks
+
+    # back to argo detail page
+    visit "#{Settings.argo_url}/view/#{druid}"
+
+    # release to Earthworks
+    click_link_or_button 'Manage release'
+    select 'Earthworks', from: 'to'
+    click_link_or_button('Submit')
+    expect(page).to have_text('Release object job was successfully created.')
+
+    # pause for a couple seconds for release to happen
+    sleep 2
+
+    # go to Earthworks and verify it was released
+    visit "#{Settings.earthworks_url}/stanford-#{bare_druid}"
+    reload_page_until_timeout!(text: 'Air Monitoring Stations: California, 2001-2003')
   end
 end

--- a/spec/features/preassembly_gis_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_accessioning_spec.rb
@@ -134,6 +134,15 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     # verify that the content type is "geo"
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('geo')
 
+    # release to Earthworks
+    click_link_or_button 'Manage release'
+    select 'Earthworks', from: 'to'
+    click_link_or_button('Submit')
+    expect(page).to have_text('Release object job was successfully created.')
+
+    # pause for a couple seconds for release to happen
+    sleep 2
+
     # This section confirms the object has been published to PURL
     # wait for the PURL name to be published by checking for collection name and check for bits of expected metadata
     expect_text_on_purl_page(druid:, text: collection_name)
@@ -149,21 +158,6 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     expect(page).to have_text('Scale not given ; EPSG::3310') # map data
     expect(page).to have_text('Geospatial data') # genre
     expect(page).to have_text('Cartographic dataset') # genre
-
-    # back to argo detail page
-    visit "#{Settings.argo_url}/view/#{druid}"
-
-    # release to Earthworks
-    click_link_or_button 'Manage release'
-    select 'Earthworks', from: 'to'
-    click_link_or_button('Submit')
-    expect(page).to have_text('Release object job was successfully created.')
-
-    # pause for a couple seconds for release to happen
-    sleep 2
-
-    # back to purl page
-    visit "#{Settings.purl_url}/#{bare_druid}"
 
     # click Earthworks link and verify it was released
     click_link_or_button 'View in EarthWorks'


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #640 - ensure GIS items make it to Earthworks after release.  The tests already verify the PURL is there, so no additional work required for that.

Tested with main deployed to stage.