### PR TITLE
Update gis_accessioning for druid tree path structure

### DIFF
--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'druid-tools'
+
 # NOTE: this spec will be skipped unless run on staging, since there is no geoserver-qa
 RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' do
   let(:start_url) { "#{Settings.argo_url}/registration" }
@@ -39,7 +41,7 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     # Should this test data be deleted from the server,
     # a zipped copy is available at spec/fixtures/gis_integration_test_data.zip
     test_data_source_folder = File.join(Settings.gis.robots_content_root, 'integration_test_data')
-    test_data_destination_folder = File.join(Settings.gis.robots_content_root, bare_druid, 'temp')
+    test_data_destination_folder = File.join(DruidTools::Druid.new(druid, Settings.gis.robots_content_root).path, 'content')
     copy_command = "ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
                    "\"mkdir -p #{test_data_destination_folder} " \
                    "&& cp #{test_data_source_folder}/* #{test_data_destination_folder}\""


### PR DESCRIPTION
## Why was this change made? 🤔

Updated intetgration test to go with:

https://github.com/sul-dlss/gis-robot-suite/pull/834
https://github.com/sul-dlss/workflow-server-rails/pull/729
https://github.com/sul-dlss/pre-assembly/pull/1412

Example: https://argo-stage.stanford.edu/view/druid:rw641dn6622

## Was README.md updated if necessary? 🤨


