### PR TITLE
Change the default SearchWorks URL

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -47,8 +47,8 @@ gis:
 
 test_folio_instance_hrid: 'a10065784'
 
-# note for purl_url: there is no purl for qa;  sul-h2-qa uses stage ...
-purl_url: 'https://sul-purl-stage.stanford.edu' # from shared_configs for sul-h2-stage
+purl_url: 'https://sul-purl-stage.stanford.edu' # there is no QA environment for Purl
+searchworks_url: 'https://searchworks-preview-stage.stanford.edu' # there is no QA environment for SearchWorks
 preassembly:
   username: 'preassembly'
   bundle_directory: '/dor/staging/integration-tests/files-reaccessioning-test'

--- a/spec/features/goobi_accessioning_spec.rb
+++ b/spec/features/goobi_accessioning_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'Create and accession object via Goobi', if: $sdr_env == 'stage' 
     expect_text_on_purl_page(druid:, text: object_label)
     expect_link_on_purl_page(druid:,
                              text: 'View in SearchWorks',
-                             href: "https://searchworks.stanford.edu/view/#{bare_object_druid}")
+                             href: "#{Settings.searchworks_url}/view/#{bare_object_druid}")
     iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
     iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
     canvas_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, '@id')


### PR DESCRIPTION
# Why was this change made?

purl-stage is pointing at SearchWorks-preview-stage, not prod. This allow the Goobi test to pass as of 3/4/24.
