### PR TITLE
Remove version select field from Argo version modal

### DIFF
--- a/spec/features/h2_object_creation_spec.rb
+++ b/spec/features/h2_object_creation_spec.rb
@@ -155,7 +155,6 @@ RSpec.describe 'Use H2 to create a collection and an item object belonging to it
     # open a new version so we can manage embargo
     click_link_or_button 'Unlock to make changes to this object'
     within '.modal-dialog' do
-      select 'Admin', from: 'Type'
       fill_in 'Version description', with: 'opening version for integration testing'
       click_link_or_button 'Open Version'
     end

--- a/spec/features/item_creation_no_files_or_collection_spec.rb
+++ b/spec/features/item_creation_no_files_or_collection_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe 'Use Argo to create an item object without any files and no colle
     # open a new version
     click_link_or_button 'Unlock to make changes to this object'
     within '.modal-dialog' do
-      select 'Admin', from: 'Type'
       fill_in 'Version description', with: 'opening version for integration testing'
       click_link_or_button 'Open Version'
     end


### PR DESCRIPTION
# Why was this change made?

We removed this as part of the ongoing versioning-related work cycle. This lets these two tests pass.

# Was README.md updated if necessary?

No
