### PR TITLE
Prefer setting SSH ProxyJump in config over command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the `Other Configuration` section below for
 
 1. Connect to Stanford VPN (full-tunnel or split-tunnel)
 1. Ensure you have a valid, non-expired Kerberos ticket (use `klist` to verify, or run `kinit` to refresh)
+1. Set up SSH per [DLSS developer best practices](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/ssh_configuration.md)
 1. See the `Authentication Configuration` section below to set up necessary credentials:
 - dor_services_app credentials
 - etd credentials
@@ -130,4 +131,3 @@ If you find you need to modify the default window size for either browser---*e.g
 ### Increase Timeout Values
 
 If you are experiencing timeout errors when running tests, you may override the default timeout values by adding `timeouts.capybara`, `timeouts.bulk_action`, and/or `timeouts.workflow` in `config/settings.local.yml` depending on where you see timeouts.
-

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,5 +56,3 @@ preassembly:
   gis_bundle_directory: '/dor/staging/integration-tests/gis-test'
 
 earthworks_url: 'https://earthworks-stage.stanford.edu/catalog'
-
-deployment_host: sdr-infra.stanford.edu

--- a/spec/features/gis_accessioning_spec.rb
+++ b/spec/features/gis_accessioning_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Create and accession GIS item object', if: $sdr_env == 'stage' d
     # a zipped copy is available at spec/fixtures/gis_integration_test_data_vector.zip
     test_data_source_folder = File.join(Settings.gis.robots_content_root, 'integration_test_data_vector')
     test_data_destination_folder = File.join(DruidTools::Druid.new(druid, Settings.gis.robots_content_root).path, 'content')
-    copy_command = "ssh -oProxyJump=#{Settings.deployment_host} #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
+    copy_command = "ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
                    "\"mkdir -p #{test_data_destination_folder} " \
                    "&& cp #{test_data_source_folder}/* #{test_data_destination_folder}\""
     `#{copy_command}`

--- a/spec/features/preassembly_gis_raster_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_raster_accessioning_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     clear_downloads
     FileUtils.rm_rf(bare_druid)
     unless bare_druid.empty?
-      `ssh -oProxyJump=#{Settings.deployment_host} #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
+      `ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
       #{preassembly_bundle_dir}/content && rm -fr #{preassembly_bundle_dir}/manifest.csv`
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     # a zipped copy is available at spec/fixtures/gis_integration_test_data_raster.zip
     test_data_source_folder = File.join(Settings.gis.robots_content_root, 'integration_test_data_raster')
     test_data_destination_folder = File.join(Settings.preassembly.gis_bundle_directory, 'content')
-    copy_command = "ssh -oProxyJump=#{Settings.deployment_host} #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
+    copy_command = "ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
                    "\"mkdir -p #{test_data_destination_folder} " \
                    "&& cp #{test_data_source_folder}/* #{test_data_destination_folder}\""
     `#{copy_command}`
@@ -73,7 +73,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
 
     # create manifest.csv file and scp it to preassembly staging directory
     File.write(local_manifest_location, preassembly_manifest_csv)
-    manifest_copy_command = "scp -oProxyJump=#{Settings.deployment_host} #{local_manifest_location} #{remote_manifest_location}"
+    manifest_copy_command = "scp #{local_manifest_location} #{remote_manifest_location}"
     `#{manifest_copy_command}`
     unless $CHILD_STATUS.success?
       raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")

--- a/spec/features/preassembly_gis_vector_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_vector_accessioning_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     clear_downloads
     FileUtils.rm_rf(bare_druid)
     unless bare_druid.empty?
-      `ssh -oProxyJump=#{Settings.deployment_host} #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
+      `ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
       #{preassembly_bundle_dir}/content && rm -fr #{preassembly_bundle_dir}/manifest.csv`
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     # a zipped copy is available at spec/fixtures/gis_integration_test_data_vector.zip
     test_data_source_folder = File.join(Settings.gis.robots_content_root, 'integration_test_data_vector')
     test_data_destination_folder = File.join(Settings.preassembly.gis_bundle_directory, 'content')
-    copy_command = "ssh -oProxyJump=#{Settings.deployment_host} #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
+    copy_command = "ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} " \
                    "\"mkdir -p #{test_data_destination_folder} " \
                    "&& cp #{test_data_source_folder}/* #{test_data_destination_folder}\""
     `#{copy_command}`
@@ -73,7 +73,7 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
 
     # create manifest.csv file and scp it to preassembly staging directory
     File.write(local_manifest_location, preassembly_manifest_csv)
-    manifest_copy_command = "scp -oProxyJump=#{Settings.deployment_host} #{local_manifest_location} #{remote_manifest_location}"
+    manifest_copy_command = "scp #{local_manifest_location} #{remote_manifest_location}"
     `#{manifest_copy_command}`
     unless $CHILD_STATUS.success?
       raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")

--- a/spec/features/preassembly_hfs_accessioning_spec.rb
+++ b/spec/features/preassembly_hfs_accessioning_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Create and re-accession object with hierarchical files via Pre-a
 
     # create manifest.csv file and scp it to preassembly staging directory
     File.write(local_manifest_location, preassembly_manifest_csv)
-    `scp -oProxyJump=#{Settings.deployment_host} #{local_manifest_location} #{remote_manifest_location}`
+    `scp #{local_manifest_location} #{remote_manifest_location}`
     unless $CHILD_STATUS.success?
       raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
     end

--- a/spec/features/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly_reaccessioning_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     clear_downloads
     FileUtils.rm_rf(bare_druid)
     unless bare_druid.empty?
-      `ssh -oProxyJump=#{Settings.deployment_host} #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
+      `ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
       #{preassembly_bundle_dir}/#{bare_druid}`
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
 
     # create manifest.csv file and scp it to preassembly staging directory
     File.write(local_manifest_location, preassembly_manifest_csv)
-    `scp -oProxyJump=#{Settings.deployment_host} #{local_manifest_location} #{remote_manifest_location}`
+    `scp #{local_manifest_location} #{remote_manifest_location}`
     unless $CHILD_STATUS.success?
       raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
     end
@@ -150,14 +150,14 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     delete_download(download)
 
     # scp file manifest to preassembly
-    `scp -oProxyJump=#{Settings.deployment_host} #{local_file_manifest_location} #{remote_manifest_location}`
+    `scp #{local_file_manifest_location} #{remote_manifest_location}`
     unless $CHILD_STATUS.success?
       raise("unable to scp #{local_file_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
     end
 
     # scp manifest for reaccession to preassembly
     File.write(local_manifest_location, preassembly_reaccession_manifest_csv)
-    `scp -oProxyJump=#{Settings.deployment_host} #{local_manifest_location} #{remote_manifest_location}`
+    `scp #{local_manifest_location} #{remote_manifest_location}`
     unless $CHILD_STATUS.success?
       raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
     end
@@ -170,7 +170,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     FileUtils.cp('spec/fixtures/vision_for_stanford.jpg', bare_druid)
 
     # scp druid directory to preassembly
-    `scp -oProxyJump=#{Settings.deployment_host} -r #{bare_druid} #{remote_manifest_location}`
+    `scp -r #{bare_druid} #{remote_manifest_location}`
     unless $CHILD_STATUS.success? # rubocop:disable Style/IfUnlessModifier
       raise("unable to scp #{bare_druid} #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
     end

--- a/spec/features/web_archive_accessioning_spec.rb
+++ b/spec/features/web_archive_accessioning_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
   let(:archived_url) { "#{Settings.was_playback_url}/*/#{url_in_wayback}" }
 
   before do
-    `ssh -oProxyJump=#{Settings.deployment_host} #{Settings.was_registrar.username}@#{Settings.was_registrar.host} mkdir -p \
+    `ssh #{Settings.was_registrar.username}@#{Settings.was_registrar.host} mkdir -p \
          #{Settings.was_registrar.jobs_directory}/#{job_specific_directory}`
     raise("unable to create job directory: #{$CHILD_STATUS.inspect}") unless $CHILD_STATUS.success?
 
-    `scp -oProxyJump=#{Settings.deployment_host} #{updated_warc.path} #{remote_path}`
+    `scp #{updated_warc.path} #{remote_path}`
 
     raise("unable to scp #{updated_warc_path} to #{remote_path}: #{$CHILD_STATUS.inspect}") unless $CHILD_STATUS.success?
 


### PR DESCRIPTION
# Why was this change made?

Doing so allows us to use a more sophisticated setup using SSH multiplexing, holding a connection open for a short period of time to reduce the overall number of MFA pushes. This change depends on all of us devs having some common SSH config which will be shared and documented elsewhere.

Blocked by https://github.com/sul-dlss/DeveloperPlaybook/pull/230
