### PR TITLE
[HOLD] Test release of a FOLIO item

### DIFF
--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -111,5 +111,19 @@ RSpec.describe 'SDR deposit' do
 
     # Check publishing
     expect_published_files(druid:, filenames: ['Gemfile.lock', 'config/settings.yml'])
+
+    # Release to Searchworks
+    visit "#{start_url}/view/#{druid}"
+    click_link_or_button 'Manage release'
+    select 'Searchworks', from: 'to'
+    click_link_or_button('Submit')
+    expect(page).to have_text('Release object job was successfully created.')
+
+    # pause for release to happen
+    sleep 2
+    visit "#{start_url}/view/#{druid}"
+    reload_page_until_timeout! do
+      page.has_selector?('#workflow-details-status-releaseWF', text: 'completed', wait: 1)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Include release of an item with a FOLIO HRID to include testing of updating the 856 in the FOLIO record. 

PR in draft because this test will fail until folio_client is updated to send MARC JSON that is Poppy and Nolana compliant. 

## Was README.md updated if necessary? 🤨


