### PR TITLE
OCR Image/Document Spec

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,7 @@ preassembly:
   username: 'preassembly'
   bundle_directory: '/dor/staging/integration-tests/files-reaccessioning-test'
   ocr_bundle_directory: '/dor/staging/integration-tests/ocr-test'
+  ocr_document_bundle_directory: '/dor/staging/integration-tests/ocr-test-document'
   hfs_bundle_directory: '/dor/staging/integration-tests/hierarchical-file-test'
   gis_bundle_directory: '/dor/staging/integration-tests/gis-test'
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,6 +52,7 @@ searchworks_url: 'https://searchworks-preview-stage.stanford.edu' # there is no 
 preassembly:
   username: 'preassembly'
   bundle_directory: '/dor/staging/integration-tests/files-reaccessioning-test'
+  ocr_bundle_directory: '/dor/staging/integration-tests/ocr-test'
   hfs_bundle_directory: '/dor/staging/integration-tests/hierarchical-file-test'
   gis_bundle_directory: '/dor/staging/integration-tests/gis-test'
 

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -13,3 +13,5 @@ was_registrar:
   jobs_directory: '/was_unaccessioned_data/jobs'
   url: 'https://was-registrar-app-qa.stanford.edu'
   username: 'was'
+ocr:
+  enabled: true

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -13,3 +13,5 @@ was_registrar:
   jobs_directory: '/was_unaccessioned_data/jobs'
   url: 'https://was-registrar-app-stage.stanford.edu'
   username: 'was'
+ocr:
+  enabled: false

--- a/spec/features/preassembly_gis_raster_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_raster_accessioning_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     visit Settings.preassembly.url
     expect(page).to have_css('h1', text: 'Complete the form below')
 
+    # sleep 1 # if you notice the project name not filling in completely, try this to
+    #           give the page a moment to load so we fill in the full text field
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
     select 'Geo', from: 'Content structure'

--- a/spec/features/preassembly_gis_vector_accessioning_spec.rb
+++ b/spec/features/preassembly_gis_vector_accessioning_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage' do
     visit Settings.preassembly.url
     expect(page).to have_css('h1', text: 'Complete the form below')
 
+    # sleep 1 # if you notice the project name not filling in completely, try this to
+    #           give the page a moment to load so we fill in the full text field
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
     select 'Geo', from: 'Content structure'

--- a/spec/features/preassembly_hfs_accessioning_spec.rb
+++ b/spec/features/preassembly_hfs_accessioning_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe 'Create and re-accession object with hierarchical files via Pre-a
     visit Settings.preassembly.url
     expect(page).to have_css('h1', text: 'Complete the form below')
 
+    # sleep 1 # if you notice the project name not filling in completely, try this to
+    #           give the page a moment to load so we fill in the full text field
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
     select 'File', from: 'Content structure'

--- a/spec/features/preassembly_ocr_document_spec.rb
+++ b/spec/features/preassembly_ocr_document_spec.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'druid-tools'
+
+# Preassembly requires that files to be included in an object must be available on a mounted drive
+# To this end, files have been placed on Settings.preassembly.host at Settings.preassembly.bundle_directory
+# This spec is only run if OCR is enabled in the environment specific settings file
+RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRed', if: Settings.ocr.enabled do
+  bare_druid = '' # used for HEREDOC preassembly manifest files (can't be memoized)
+  let(:start_url) { "#{Settings.argo_url}/registration" }
+  let(:preassembly_bundle_dir) { Settings.preassembly.ocr_document_bundle_directory } # where we will stage the ocr content
+  let(:remote_manifest_location) do
+    "#{Settings.preassembly.username}@#{Settings.preassembly.host}:#{preassembly_bundle_dir}"
+  end
+  let(:local_manifest_location) { 'tmp/manifest.csv' }
+  let(:local_file_manifest_location) { 'tmp/file_manifest.csv' }
+  let(:preassembly_project_name) { "IntegrationTest-preassembly-document-ocr-#{random_noun}-#{random_alpha}" }
+  let(:source_id_random_word) { "#{random_noun}-#{random_alpha}" }
+  let(:source_id) { "document-ocr-integration-test:#{source_id_random_word}" }
+  let(:label_random_words) { random_phrase }
+  let(:object_label) { "document ocr integration test #{label_random_words}" }
+  let(:collection_name) { 'integration-testing' }
+  let(:preassembly_manifest_csv) do
+    <<~CSV
+      druid,object
+      #{bare_druid},content
+    CSV
+  end
+  let(:preassembly_reaccession_manifest_csv) do
+    <<~CSV
+      druid,object
+      #{bare_druid},#{bare_druid}
+    CSV
+  end
+
+  before do
+    authenticate!(start_url:,
+                  expected_text: 'Register DOR Items')
+  end
+
+  after do
+    clear_downloads
+    FileUtils.rm_rf(bare_druid)
+    unless bare_druid.empty?
+      `ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
+      #{preassembly_bundle_dir}/#{bare_druid}`
+    end
+  end
+
+  scenario do
+    select 'integration-testing', from: 'Admin Policy'
+    select collection_name, from: 'Collection'
+    select 'document', from: 'Content Type'
+    fill_in 'Project Name', with: 'Integration Test - Document OCR via Preassembly'
+    fill_in 'Source ID', with: "#{source_id}-#{random_alpha}"
+    fill_in 'Label', with: object_label
+
+    click_button 'Register'
+
+    # wait for object to be registered
+    expect(page).to have_text 'Items successfully registered.'
+
+    bare_druid = find('table a').text
+    druid = "druid:#{bare_druid}"
+    puts " *** preassembly document accessioning druid: #{druid} ***" # useful for debugging
+
+    # create manifest.csv file and scp it to preassembly staging directory
+    File.write(local_manifest_location, preassembly_manifest_csv)
+    `scp #{local_manifest_location} #{remote_manifest_location}`
+    unless $CHILD_STATUS.success?
+      raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
+    end
+
+    visit Settings.preassembly.url
+    expect(page).to have_css('h3', text: 'Complete the form below')
+
+    fill_in 'Project name', with: preassembly_project_name
+    select 'Pre Assembly Run', from: 'Job type'
+    select 'Document', from: 'Content structure'
+    fill_in 'Staging location', with: preassembly_bundle_dir
+    choose 'batch_context_manually_corrected_ocr_false' # indicate documents do not have pre-existing OCR
+    choose 'batch_context_run_ocr_true' # yes, run OCR
+
+    click_link_or_button 'Submit'
+    expect(page).to have_text 'Success! Your job is queued. ' \
+                              'A link to job output will be emailed to you upon completion.'
+
+    # go to job details page, download result
+    first('td > a').click
+    expect(page).to have_text preassembly_project_name
+
+    # wait for preassembly background job to finish
+    reload_page_until_timeout! do
+      page.has_link?('Download', wait: 1)
+    end
+
+    click_link_or_button 'Download'
+    wait_for_download
+    yaml = YAML.load_file(download)
+    expect(yaml[:status]).to eq 'success'
+    # delete the downloaded YAML file, so we don't pick it up by mistake during the re-accession
+    delete_download(download)
+
+    # ensure accessioning completed ... we should have two versions now,
+    # with all files there, and an ocrWF, organized into specified resources
+    visit "#{Settings.argo_url}/view/#{druid}"
+
+    # Check that ocrWF ran
+    reload_page_until_timeout!(text: 'ocrWF')
+
+    # TODO: remove this when we actually have ocr-create complete with the process
+    # this manually completes the ocr-create step
+    click_link_or_button 'ocrWF'
+    first('button', text: 'Set to completed').click
+    click_link_or_button 'Cancel' # close the workflow window
+
+    # Wait for the second version accessioningWF to finish
+    reload_page_until_timeout!(text: 'v2 Accessioned')
+
+    # Check that the version description is correct for the second version
+    reload_page_until_timeout!(text: 'Start OCR workflow')
+
+    # TODO: check that OCR was successful by looking for extra files that were created, and update expectations below
+
+    files = all('tr.file')
+
+    expect(files.size).to eq 1
+    expect(files[0].text).to match(%r{testocr-image-only.pdf application/pdf 9\d\d KB})
+
+    expect(find_table_cell_following(header_text: 'Content type').text).to eq('document') # filled in by accessioning
+
+    # check technical metadata for all non-thumbnail files
+    reload_page_until_timeout! do
+      click_link_or_button 'Technical metadata' # expand the Technical metadata section
+
+      # this is a hack that forces the event section to scroll into view; the section
+      # is lazily loaded, and won't actually be requested otherwise, even if the button
+      # is clicked to expand the event section.
+      page.execute_script 'window.scrollBy(0,100);'
+
+      # events are loaded lazily, give the network a few moments
+      page.has_text?('v2 Accessioned', wait: 2)
+    end
+    page.has_text?('filetype', count: 1)
+    page.has_text?('file_modification', count: 1)
+
+    # This section confirms the object has been published to PURL
+    expect_text_on_purl_page(druid:, text: collection_name)
+    expect_text_on_purl_page(druid:, text: object_label)
+
+    # The below confirms that preservation replication is working: we only replicate a
+    # Moab version once it's been written successfully to on prem storage roots, and
+    # we only log an event to dor-services-app after a version has successfully replicated
+    # to a cloud endpoint.  So, confirming that both versions of our test object have
+    # replication events logged for all three cloud endpoints is a good basic test of the
+    # entire preservation flow.
+    visit "#{Settings.argo_url}/view/#{druid}"
+    prefixed_druid = "druid:#{bare_druid}"
+    druid_tree_str = DruidTools::Druid.new(prefixed_druid).tree.join('/')
+
+    latest_s3_key = "#{druid_tree_str}.v0002.zip"
+    reload_page_until_timeout! do
+      click_link_or_button 'Events' # expand the Events section
+
+      # this is a hack that forces the event section to scroll into view; the section
+      # is lazily loaded, and won't actually be requested otherwise, even if the button
+      # is clicked to expand the event section.
+      page.execute_script 'window.scrollBy(0,100);'
+
+      # events are loaded lazily, give the network a few moments
+      page.has_text?(latest_s3_key, wait: 3)
+    end
+
+    # the event log should eventually contain an event for replication of each version that
+    # this test created to every endpoint we archive to
+    poll_for_matching_events!(prefixed_druid) do |events|
+      (1..2).all? do |cur_version|
+        cur_s3_key = "#{druid_tree_str}.v000#{cur_version}.zip"
+
+        %w[aws_s3_west_2 ibm_us_south aws_s3_east_1].all? do |endpoint_name|
+          events.any? do |event|
+            event[:event_type] == 'druid_version_replicated' &&
+              event[:data]['parts_info'] &&
+              event[:data]['parts_info'].size == 1 && # we only expect one part for this small object
+              event[:data]['parts_info'].first['s3_key'] == cur_s3_key &&
+              event[:data]['endpoint_name'] == endpoint_name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/preassembly_ocr_document_spec.rb
+++ b/spec/features/preassembly_ocr_document_spec.rb
@@ -108,12 +108,6 @@ RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRe
     # Check that ocrWF ran
     reload_page_until_timeout!(text: 'ocrWF')
 
-    # TODO: remove this when we actually have ocr-create complete with the process
-    # this manually completes the ocr-create step
-    click_link_or_button 'ocrWF'
-    first('button', text: 'Set to completed').click
-    click_link_or_button 'Cancel' # close the workflow window
-
     # Wait for the second version accessioningWF to finish
     reload_page_until_timeout!(text: 'v2 Accessioned')
 

--- a/spec/features/preassembly_ocr_document_spec.rb
+++ b/spec/features/preassembly_ocr_document_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRe
     end
 
     visit Settings.preassembly.url
-    expect(page).to have_css('h3', text: 'Complete the form below')
+    expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'

--- a/spec/features/preassembly_ocr_document_spec.rb
+++ b/spec/features/preassembly_ocr_document_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRe
     visit Settings.preassembly.url
     expect(page).to have_css('h1', text: 'Complete the form below')
 
+    # sleep 1 # if you notice the project name not filling in completely, try this to
+    #           give the page a moment to load so we fill in the full text field
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
     select 'Document', from: 'Content structure'

--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     select 'Pre Assembly Run', from: 'Job type'
     select 'Image', from: 'Content structure'
     fill_in 'Staging location', with: preassembly_bundle_dir
-    choose 'No' # images do not have pre-existing OCR
-    choose 'Yes. Run ABBYY OCR.' # yes, run OCR
+    choose 'batch_context_manually_corrected_ocr_false' # indicate images do not have pre-existing OCR
+    choose 'batch_context_run_ocr_true' # yes, run OCR
 
     click_link_or_button 'Submit'
     expect(page).to have_text 'Success! Your job is queued. ' \

--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     visit Settings.preassembly.url
     expect(page).to have_css('h1', text: 'Complete the form below')
 
+    # sleep 1 # if you notice the project name not filling in completely, try this to
+    #           give the page a moment to load so we fill in the full text field
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
     select 'Image', from: 'Content structure'

--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     end
 
     visit Settings.preassembly.url
-    expect(page).to have_css('h3', text: 'Complete the form below')
+    expect(page).to have_css('h1', text: 'Complete the form below')
 
     fill_in 'Project name', with: preassembly_project_name
     select 'Pre Assembly Run', from: 'Job type'
@@ -80,6 +80,11 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     fill_in 'Staging location', with: preassembly_bundle_dir
     choose 'batch_context_manually_corrected_ocr_false' # indicate images do not have pre-existing OCR
     choose 'batch_context_run_ocr_true' # yes, run OCR
+
+    # NOTE: the following commented out code is for testing the language selector, but submit seems to hang
+    # first('button[aria-label="toggle dropdown"]').click # open the dropdown for language selector
+    # check 'batch_context_ocr_languages_english' # choose a couple languages
+    # check 'batch_context_ocr_languages_spanish'
 
     click_link_or_button 'Submit'
     expect(page).to have_text 'Success! Your job is queued. ' \

--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -108,12 +108,6 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     # Check that ocrWF ran
     reload_page_until_timeout!(text: 'ocrWF')
 
-    # TODO: remove this when we actually have ocr-create complete with the process
-    # this manually completes the ocr-create step
-    click_link_or_button 'ocrWF'
-    first('button', text: 'Set to completed').click
-    click_link_or_button 'Cancel' # close the workflow window
-
     # Wait for the second version accessioningWF to finish
     reload_page_until_timeout!(text: 'v2 Accessioned')
 

--- a/spec/features/preassembly_ocr_spec.rb
+++ b/spec/features/preassembly_ocr_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'druid-tools'
+
+# Preassembly requires that files to be included in an object must be available on a mounted drive
+# To this end, files have been placed on Settings.preassembly.host at Settings.preassembly.bundle_directory
+# This spec is only run if OCR is enabled in the environment specific settings file
+RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed', if: Settings.ocr.enabled do
+  bare_druid = '' # used for HEREDOC preassembly manifest files (can't be memoized)
+  let(:start_url) { "#{Settings.argo_url}/registration" }
+  let(:preassembly_bundle_dir) { Settings.preassembly.ocr_bundle_directory } # where we will stage the ocr content
+  let(:remote_manifest_location) do
+    "#{Settings.preassembly.username}@#{Settings.preassembly.host}:#{preassembly_bundle_dir}"
+  end
+  let(:local_manifest_location) { 'tmp/manifest.csv' }
+  let(:local_file_manifest_location) { 'tmp/file_manifest.csv' }
+  let(:preassembly_project_name) { "IntegrationTest-preassembly-image-ocr-#{random_noun}-#{random_alpha}" }
+  let(:source_id_random_word) { "#{random_noun}-#{random_alpha}" }
+  let(:source_id) { "image-ocr-integration-test:#{source_id_random_word}" }
+  let(:label_random_words) { random_phrase }
+  let(:object_label) { "image ocr integration test #{label_random_words}" }
+  let(:collection_name) { 'integration-testing' }
+  let(:preassembly_manifest_csv) do
+    <<~CSV
+      druid,object
+      #{bare_druid},content
+    CSV
+  end
+  let(:preassembly_reaccession_manifest_csv) do
+    <<~CSV
+      druid,object
+      #{bare_druid},#{bare_druid}
+    CSV
+  end
+
+  before do
+    authenticate!(start_url:,
+                  expected_text: 'Register DOR Items')
+  end
+
+  after do
+    clear_downloads
+    FileUtils.rm_rf(bare_druid)
+    unless bare_druid.empty?
+      `ssh #{Settings.preassembly.username}@#{Settings.preassembly.host} rm -rf \
+      #{preassembly_bundle_dir}/#{bare_druid}`
+    end
+  end
+
+  scenario do
+    select 'integration-testing', from: 'Admin Policy'
+    select collection_name, from: 'Collection'
+    select 'image', from: 'Content Type'
+    fill_in 'Project Name', with: 'Integration Test - Image OCR via Preassembly'
+    fill_in 'Source ID', with: "#{source_id}-#{random_alpha}"
+    fill_in 'Label', with: object_label
+
+    click_button 'Register'
+
+    # wait for object to be registered
+    expect(page).to have_text 'Items successfully registered.'
+
+    bare_druid = find('table a').text
+    druid = "druid:#{bare_druid}"
+    puts " *** preassembly image accessioning druid: #{druid} ***" # useful for debugging
+
+    # create manifest.csv file and scp it to preassembly staging directory
+    File.write(local_manifest_location, preassembly_manifest_csv)
+    `scp #{local_manifest_location} #{remote_manifest_location}`
+    unless $CHILD_STATUS.success?
+      raise("unable to scp #{local_manifest_location} to #{remote_manifest_location} - got #{$CHILD_STATUS.inspect}")
+    end
+
+    visit Settings.preassembly.url
+    expect(page).to have_css('h3', text: 'Complete the form below')
+
+    fill_in 'Project name', with: preassembly_project_name
+    select 'Pre Assembly Run', from: 'Job type'
+    select 'Image', from: 'Content structure'
+    fill_in 'Staging location', with: preassembly_bundle_dir
+    choose 'No' # images do not have pre-existing OCR
+    choose 'Yes. Run ABBYY OCR.' # yes, run OCR
+
+    click_link_or_button 'Submit'
+    expect(page).to have_text 'Success! Your job is queued. ' \
+                              'A link to job output will be emailed to you upon completion.'
+
+    # go to job details page, download result
+    first('td > a').click
+    expect(page).to have_text preassembly_project_name
+
+    # wait for preassembly background job to finish
+    reload_page_until_timeout! do
+      page.has_link?('Download', wait: 1)
+    end
+
+    click_link_or_button 'Download'
+    wait_for_download
+    yaml = YAML.load_file(download)
+    expect(yaml[:status]).to eq 'success'
+    # delete the downloaded YAML file, so we don't pick it up by mistake during the re-accession
+    delete_download(download)
+
+    # ensure accessioning completed ... we should have two versions now,
+    # with all files there, and an ocrWF, organized into specified resources
+    visit "#{Settings.argo_url}/view/#{druid}"
+
+    # Check that ocrWF ran
+    reload_page_until_timeout!(text: 'ocrWF')
+
+    # TODO: remove this when we actually have ocr-create complete with the process
+    # this manually completes the ocr-create step
+    click_link_or_button 'ocrWF'
+    first('button', text: 'Set to completed').click
+    click_link_or_button 'Cancel' # close the workflow window
+
+    # Wait for the second version accessioningWF to finish
+    reload_page_until_timeout!(text: 'v2 Accessioned')
+
+    # Check that the version description is correct for the second version
+    reload_page_until_timeout!(text: 'Start OCR workflow')
+
+    # TODO: check that OCR was successful by looking for extra files that were created, and update expectations below
+
+    files = all('tr.file')
+
+    expect(files.size).to eq 4
+    expect(files[0].text).to match(%r{testocr.tiff image/tiff 1.1\d MB})
+    expect(files[1].text).to match(%r{testocr.jp2 image/jp2 95\.*\d* KB})
+    expect(files[2].text).to match(%r{testocr2.tiff image/tiff 177 KB})
+    expect(files[3].text).to match(%r{testocr2.jp2 image/jp2 25\.*\d* KB})
+
+    expect(find_table_cell_following(header_text: 'Content type').text).to eq('image') # filled in by accessioning
+
+    # check technical metadata for all non-thumbnail files
+    reload_page_until_timeout! do
+      click_link_or_button 'Technical metadata' # expand the Technical metadata section
+
+      # this is a hack that forces the event section to scroll into view; the section
+      # is lazily loaded, and won't actually be requested otherwise, even if the button
+      # is clicked to expand the event section.
+      page.execute_script 'window.scrollBy(0,100);'
+
+      # events are loaded lazily, give the network a few moments
+      page.has_text?('v2 Accessioned', wait: 2)
+    end
+    page.has_text?('filetype', count: 2)
+    page.has_text?('file_modification', count: 2)
+
+    # This section confirms the object has been published to PURL and has a
+    # valid IIIF manifest
+    # wait for the PURL name to be published by checking for collection name
+    expect_text_on_purl_page(druid:, text: collection_name)
+    expect_text_on_purl_page(druid:, text: object_label)
+    iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
+    iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
+    canvas_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, '@id')
+    canvas = JSON.parse(Faraday.get(canvas_url).body)
+    image_url = canvas.dig('images', 0, 'resource', '@id')
+    image_response = Faraday.get(image_url)
+    expect(image_response.status).to eq(200)
+    expect(image_response.headers['content-type']).to include('image/jpeg')
+
+    # The below confirms that preservation replication is working: we only replicate a
+    # Moab version once it's been written successfully to on prem storage roots, and
+    # we only log an event to dor-services-app after a version has successfully replicated
+    # to a cloud endpoint.  So, confirming that both versions of our test object have
+    # replication events logged for all three cloud endpoints is a good basic test of the
+    # entire preservation flow.
+    visit "#{Settings.argo_url}/view/#{druid}"
+    prefixed_druid = "druid:#{bare_druid}"
+    druid_tree_str = DruidTools::Druid.new(prefixed_druid).tree.join('/')
+
+    latest_s3_key = "#{druid_tree_str}.v0002.zip"
+    reload_page_until_timeout! do
+      click_link_or_button 'Events' # expand the Events section
+
+      # this is a hack that forces the event section to scroll into view; the section
+      # is lazily loaded, and won't actually be requested otherwise, even if the button
+      # is clicked to expand the event section.
+      page.execute_script 'window.scrollBy(0,100);'
+
+      # events are loaded lazily, give the network a few moments
+      page.has_text?(latest_s3_key, wait: 3)
+    end
+
+    # the event log should eventually contain an event for replication of each version that
+    # this test created to every endpoint we archive to
+    poll_for_matching_events!(prefixed_druid) do |events|
+      (1..2).all? do |cur_version|
+        cur_s3_key = "#{druid_tree_str}.v000#{cur_version}.zip"
+
+        %w[aws_s3_west_2 ibm_us_south aws_s3_east_1].all? do |endpoint_name|
+          events.any? do |event|
+            event[:event_type] == 'druid_version_replicated' &&
+              event[:data]['parts_info'] &&
+              event[:data]['parts_info'].size == 1 && # we only expect one part for this small object
+              event[:data]['parts_info'].first['s3_key'] == cur_s3_key &&
+              event[:data]['endpoint_name'] == endpoint_name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly_reaccessioning_spec.rb
@@ -50,6 +50,9 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     select 'integration-testing', from: 'Admin Policy'
     select collection_name, from: 'Collection'
     select 'image', from: 'Content Type'
+
+    # sleep 1 # if you notice the project name not filling in completely, try this to
+    #           give the page a moment to load so we fill in the full text field
     fill_in 'Project Name', with: 'Integration Test - Image via Preassembly'
     fill_in 'Source ID', with: "#{source_id}-#{random_alpha}"
     fill_in 'Label', with: object_label


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #730 

Follow on work described in #741

This adds a new integration test to run pre-assembly for an image object and a document object which starts OCR.

It is useful during testing to let us run objects through ocrWF.

Still to do:
- [x] we can remove the manual click to "Set to completed" for `ocr-create`
- [x] we may want to add a new similar test for the document object type, which will require putting new test PDF content on the pre-assembly servers for testing against


## Was README.md updated if necessary? 🤨


