### PR TITLE
ocr txt files do not have transcription role set

### DIFF
--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     expect(files[5].text).to match(%r{testocr2.xml application/xml 8\.*\d* KB Transcription})
 
     expect(files[6].text).to match(%r{#{bare_druid}.pdf application/pdf 16\.*\d* KB Transcription})
-    expect(files[7].text).to match(%r{#{bare_druid}.txt text/plain 570 Bytes Transcription})
+    expect(files[7].text).to match(%r{#{bare_druid}.txt text/plain 570 Bytes No role})
 
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('image') # filled in by accessioning
 


### PR DESCRIPTION
## Why was this change made? 🤔

Because of https://github.com/sul-dlss/common-accessioning/pull/1286 which changes some logic with OCR



