### PR TITLE
Add csv dependency to bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'byebug'
 gem 'capybara'
 gem 'capybara_table'
 gem 'config'
+gem 'csv'
 gem 'dor-services-client', '~> 14.0'
 gem 'druid-tools' # for constructing druid tree strings easily
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
     connection_pool (2.4.1)
+    csv (3.3.0)
     deep_merge (1.2.2)
     deprecation (1.1.0)
       activesupport
@@ -245,6 +246,7 @@ DEPENDENCIES
   capybara
   capybara_table
   config
+  csv
   dor-services-client (~> 14.0)
   druid-tools
   faker

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 require 'byebug'
 require 'config'
-require 'csv'
 require 'faker'
 require 'io/console'
 require 'pry-byebug'


### PR DESCRIPTION
# Why was this change made?

This dependency is moving out of stdlib in Ruby 3.4 so it must be managed by bundler.
