### PR TITLE
Add require csv where necessary

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'byebug'
 require 'config'
+require 'csv'
 require 'faker'
 require 'io/console'
 require 'pry-byebug'


### PR DESCRIPTION
## Why was this change made? 🤔

Add `require 'csv'` in the places that we open a CSV now that the gem is explicitly included.

## Was README.md updated if necessary? 🤨


