### PR TITLE
[WIP] example load test using multiple browser sessions and world readable video on PURL/embed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'dor-services-client', '~> 14.0'
 gem 'druid-tools' # for constructing druid tree strings easily
 gem 'faker'
 gem 'faraday' # etds require POST request from registrar
+gem 'parallel'
 gem 'pry-byebug'
 gem 'rake'
 gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,7 @@ DEPENDENCIES
   druid-tools
   faker
   faraday
+  parallel
   pry-byebug
   rake
   rspec

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -15,3 +15,14 @@ was_registrar:
   username: 'was'
 ocr:
   enabled: false
+
+load_test:
+  streaming_video:
+    druids: # these should be bare druids, i.e. no druid prefix
+      # - db246zg5803
+      - qc898xy1175
+      - qb933xv2993
+      - pf759xf5671
+      # - cm856pm4228
+    multiplier: 2
+    watch_time: 60

--- a/spec/features/streaming_video_load_spec.rb
+++ b/spec/features/streaming_video_load_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe 'streaming video load test', :load_test do
+  let(:session_infos) do
+    (1..Settings.load_test.streaming_video.multiplier).map do
+      Settings.load_test.streaming_video.druids.map do |bare_druid|
+        {
+          bare_druid:,
+          session: Capybara::Session.new(Capybara.default_driver)
+        }
+      end
+    end.flatten
+  end
+
+  before do
+    Capybara.configure do |config|
+      config.threadsafe = true
+    end
+  end
+
+  scenario do
+    Parallel.each(session_infos) do |session_info|
+      puts "#{session_info[:bare_druid]}: visiting PURL"
+      session_info[:session].visit "#{Settings.purl_url}/#{session_info[:bare_druid]}"
+
+      puts "#{session_info[:bare_druid]}: allowing page to load"
+      sleep 30
+
+      puts "#{session_info[:bare_druid]}: attempting to play video"
+      expect(session_info[:session]).to have_css('button.vjs-big-play-button')
+      session_info[:session].click_button("Play Video")
+
+      puts "#{session_info[:bare_druid]}: sitting on page, trying to let video play"
+      sleep Settings.load_test.streaming_video.watch_time
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'config'
 require 'csv'
 require 'faker'
 require 'io/console'
+require 'parallel'
 require 'pry-byebug'
 require 'rubyXL'
 require 'sdr_client'
@@ -37,6 +38,8 @@ Dir[root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.include Capybara::DSL # required without `type: :feature` spec metadata, which RSpec infers
+
+  config.filter_run_excluding(:load_test) # don't run load tests by default (run with '--tag load_test' arg to override)
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Why was this change made? 🤔

we don't have a systematic way at all at the moment to test the streaming media server.  this is an attempt at helping to  automate that testing, prompted by intermittent outages (mostly at the end of 2023, once in 2024, as of early july).

## Was README.md updated if necessary? 🤨

not yet, but this change will probably warrant that.
