### PR TITLE
relax expectations for ocr specs

### DIFF
--- a/spec/features/preassembly_ocr_document_spec.rb
+++ b/spec/features/preassembly_ocr_document_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRe
 
     expect(files.size).to eq 2
     expect(files[0].text).to match(%r{testocr-image-only.pdf application/pdf 9\d\d KB})
-    expect(files[1].text).to match(%r{#{bare_druid}-generated.pdf application/pdf 16\.\d KB Transcription})
+    expect(files[1].text).to match(%r{#{bare_druid}-generated.pdf application/pdf 1\d\.\d KB Transcription})
 
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('document') # filled in by accessioning
 

--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -132,10 +132,10 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
 
     expect(files[3].text).to match(%r{testocr2.tiff image/tiff 177 KB})
     expect(files[4].text).to match(%r{testocr2.jp2 image/jp2 25\.*\d* KB})
-    expect(files[5].text).to match(%r{testocr2.xml application/xml 8\.*\d* KB Transcription})
+    expect(files[5].text).to match(%r{testocr2.xml application/xml \d\.*\d* KB Transcription})
 
-    expect(files[6].text).to match(%r{#{bare_druid}.pdf application/pdf 16\.*\d* KB Transcription})
-    expect(files[7].text).to match(%r{#{bare_druid}.txt text/plain 570 Bytes No role})
+    expect(files[6].text).to match(%r{#{bare_druid}.pdf application/pdf 1\d\.*\d* KB Transcription})
+    expect(files[7].text).to match(%r{#{bare_druid}.txt text/plain 5\d\d Bytes No role})
 
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('image') # filled in by accessioning
 


### PR DESCRIPTION
## Why was this change made? 🤔

When running on stage, the OCR accessioning produced slightly different file sizes for XML and TXT.
