### PR TITLE
fix expected text when viewing a non-latest public version in argo

### DIFF
--- a/spec/features/h2_versioned_object_creation_spec.rb
+++ b/spec/features/h2_versioned_object_creation_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe 'Use H2 to create a collection and a versioned work belonging to 
 
     # Go to public version 1, which can be withdrawn
     click_link_or_button 'Public version 1'
-    expect(page).to have_text('You are viewing an older version.')
+    expect(page).to have_text('You are viewing an older public version.')
     accept_confirm 'Once you withdraw this version, the Purl will no longer display it. Are you sure?' do
       click_link_or_button 'Withdraw'
     end
@@ -160,7 +160,7 @@ RSpec.describe 'Use H2 to create a collection and a versioned work belonging to 
     # Now restore it.
     visit "#{Settings.argo_url}/view/#{bare_druid}"
     click_link_or_button 'Public version 1'
-    expect(page).to have_text('You are viewing an older version.')
+    expect(page).to have_text('You are viewing an older public version.')
     click_link_or_button 'Restore'
     expect(page).to have_text('Restored.')
 


### PR DESCRIPTION
## Why was this change made? 🤔

so the expectation matches the actual language in the UI

<img width="1135" alt="Screenshot 2024-08-13 at 8 56 48 AM" src="https://github.com/user-attachments/assets/e570ca73-1d54-4840-912d-9ef05e5c4365">


## Was README.md updated if necessary? 🤨
n/a

