### PR TITLE
Allow configuration of firefox/geckodriver paths and disable pop-up download panel

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,8 @@ browser:
   driver: firefox
   height: 900
   width: 1440
+  geckodriver_path: ~
+  firefox_path: ~
 
 default_apo: 'druid:qc410yz8746'
 default_collection: 'druid:bc778pm9866'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,8 +8,11 @@ Capybara.enable_aria_label = true
 Capybara.run_server = false
 
 Capybara.register_driver :my_firefox_driver do |app|
+  Selenium::WebDriver::Firefox::Service::EXECUTABLE = Settings.browser.geckodriver_path if Settings.browser.geckodriver_path
+
   options = Selenium::WebDriver::Firefox::Options.new
   options.profile = Selenium::WebDriver::Firefox::Profile.new.tap do |profile|
+    profile['browser.download.alwaysOpenPanel'] = false
     profile['browser.download.dir'] = DownloadHelpers::PATH.to_s
     # profile["browser.helperApps.neverAsk.openFile"] = "application/x-yaml"
     profile['browser.download.folderList'] = 2
@@ -23,6 +26,7 @@ Capybara.register_driver :my_firefox_driver do |app|
   # NOTE: You might think the `--window-size` arg would work here. Not for me, it didn't.
   options.add_argument("--width=#{Settings.browser.width}")
   options.add_argument("--height=#{Settings.browser.height}")
+  options.binary = Settings.browser.firefox_path if Settings.browser.firefox_path
 
   Capybara::Selenium::Driver.new(app, browser: :firefox, options:)
 end


### PR DESCRIPTION
# Why was this change made?

I needed it to deal with how Firefox is being shipped in modern Ubuntu versions. I don't think it'll break anyone else since it's opt-in, but it may be good to verify that.

# Was README.md updated if necessary?

No.
