### PR TITLE
retry ocrWF fetch-files if preservation-client retrieval errors

### DIFF
--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -116,7 +116,10 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     reload_page_until_timeout!(text: 'ocrWF')
 
     # Wait for the second version accessioningWF to finish
-    reload_page_until_timeout!(text: 'v2 Accessioned')
+    workflow_retry_text = /fetch-files : Preservation::Client.*got.*from Preservation/
+    reload_page_until_timeout_with_wf_step_retry!(expected_text: 'v2 Accessioned',
+                                                  workflow: 'ocrWF',
+                                                  workflow_retry_text:)
 
     # Check that the version description is correct for the second version
     reload_page_until_timeout!(text: 'Start OCR workflow')

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -19,7 +19,7 @@ module PageHelpers
   # This method provides a way to retry a workflow step if the workflow fails with a specific error message.
   # It will stop retrying when the passed in block returns true, or if no block is given, when
   # workflow_retry_text is found in the page.
-  # @@yieldparam page [Capybara::Node::Document] the currrent page, from which we're retrying the workflow
+  # @yieldparam page [Capybara::Node::Document] the currrent page, from which we're retrying the workflow
   # @yieldreturn [boolean] done retrying the workflow if true, otherwise continue
   def reload_page_until_timeout_with_wf_step_retry!(expected_text: '',
                                                     workflow: 'accessionWF',


### PR DESCRIPTION
## Why was this change made? 🤔

this accounts for a race condition where fetch-files fails to get the files on the first try or 3, because there seems to occasionally be some lag before the files are available for read by the preservation_catalog web VMs.  previously, the spec failed on line 119 due to the workflow error.

plus an opportunistic YARD typo fix.

example of successful accessioning after manually retrying (this just has the test do the same automatically).

note: i think this is ok, and is something we've seen intermittently on stage and not worried about, including with ocrWF, but i'm not 100% sure about that.  if it feels like this is papering over a serious problem, we can work with ops to investigate the lag (probably a good idea even if this fix is also a good idea, and could reproduce using the code from before this change).

discovered incidentally when testing https://github.com/sul-dlss/dor-services-app/pull/5218

<img width="1351" alt="Screenshot 2024-11-04 at 11 15 00 PM" src="https://github.com/user-attachments/assets/5e789b98-5cd6-4934-b58b-bd069541766f">

<img width="1121" alt="Screenshot 2024-11-04 at 11 15 57 PM" src="https://github.com/user-attachments/assets/c269fe39-f89a-407e-8722-4451ecca5fe3">

<img width="1242" alt="Screenshot 2024-11-04 at 11 16 52 PM" src="https://github.com/user-attachments/assets/77c3bcaa-2b73-4ce4-8a8f-5e95fc634502">


## Was README.md updated if necessary? 🤨

n/a