### PR TITLE
Revert "retry ocrWF fetch-files if preservation-client retrieval errors"

### DIFF
--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -116,10 +116,7 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     reload_page_until_timeout!(text: 'ocrWF')
 
     # Wait for the second version accessioningWF to finish
-    workflow_retry_text = /fetch-files : Preservation::Client.*got.*from Preservation/
-    reload_page_until_timeout_with_wf_step_retry!(expected_text: 'v2 Accessioned',
-                                                  workflow: 'ocrWF',
-                                                  workflow_retry_text:)
+    reload_page_until_timeout!(text: 'v2 Accessioned')
 
     # Check that the version description is correct for the second version
     reload_page_until_timeout!(text: 'Start OCR workflow')


### PR DESCRIPTION
Reverts sul-dlss/infrastructure-integration-test#795

may be unnecessary.  try restoring retry behavior in the common-accessioning robot, see https://github.com/sul-dlss/infrastructure-integration-test/pull/795#issuecomment-2458141891

see https://github.com/sul-dlss/common-accessioning/pull/1421 for testing info.

part of https://github.com/sul-dlss/common-accessioning/issues/1420