### PR TITLE
require csv for ruby 3.4.1

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'byebug'
 require 'config'
+require 'csv'
 require 'faker'
 require 'io/console'
 require 'pry-byebug'


### PR DESCRIPTION
## Why was this change made? 🤔

need to explicitly require csv when running on ruby 3.4 or later (csv gem is already included in gemfile)

## Was README.md updated if necessary? 🤨


