### PR TITLE
Error handling improvements

### DIFF
--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe 'SDR deposit' do
         raise 'Error opening opening file modal'
       end
     rescue StandardError => e
+      # we think this happens due to network file system lag.  retrying usually works.
       puts "download attempt failed (link click text=#{gemfile_pres_link_text}): #{e.class}; #{e.inspect}; #{e}"
 
       puts "sleeping and retrying (retries_count=#{retries_count})"
@@ -102,6 +103,7 @@ RSpec.describe 'SDR deposit' do
         raise 'Error opening opening file modal'
       end
     rescue StandardError => e
+      # we think this happens due to network file system lag.  retrying usually works.
       puts "download attempt failed (link click text=#{gemfile_lock_stacks_link_text}): #{e.class}; #{e.inspect}; #{e}"
 
       puts "sleeping and retrying (retries_count=#{retries_count})"

--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -56,26 +56,62 @@ RSpec.describe 'SDR deposit' do
     # Wait for accessioningWF to finish
     reload_page_until_timeout!(text: 'v1 Accessioned')
 
-    # Download Gemfile (preserved=true) from Preservation
-    click_link_or_button 'Gemfile'
-    expect(page).to have_text 'Preservation:'
-    gemfile_pres_link = find('.modal-content a')
-    gemfile_pres_url = gemfile_pres_link['href']
-    expect(gemfile_pres_url.end_with?("/items/#{druid}/files/Gemfile/preserved?version=1")).to be true
+    retries_count = 0
+    begin
+      # Download Gemfile (preserved=true) from Preservation
+      click_link_or_button 'Gemfile'
+      expect(page).to have_text 'Preservation:'
+      gemfile_pres_link = find('.modal-content a')
+      gemfile_pres_url = gemfile_pres_link['href']
+      gemfile_pres_link_text = gemfile_pres_link.text
+      expect(gemfile_pres_url.end_with?("/items/#{druid}/files/Gemfile/preserved?version=1")).to be true
 
-    click_link_or_button gemfile_pres_link.text
+      puts "about to click on '#{gemfile_pres_link_text}' to get '#{gemfile_pres_url}'"
+      click_link_or_button gemfile_pres_link_text
+      if page.has_content?('Expected a successful response from the server, but got an error')
+        raise 'Error opening opening file modal'
+      end
+    rescue StandardError => e
+      puts "download attempt failed (link click text=#{gemfile_pres_link_text}): #{e.class}; #{e.inspect}; #{e}"
+
+      puts "sleeping and retrying (retries_count=#{retries_count})"
+      sleep 10
+      retries_count += 1
+      if retries_count < 5
+        visit "#{start_url}/view/#{druid}"
+        retry
+      end
+    end
     wait_for_download
 
     click_link_or_button 'Cancel'
 
-    # Download Gemfile.lock (shelve=true) from Stacks
-    click_link_or_button 'Gemfile.lock'
-    expect(page).to have_text 'Stacks:'
-    gemfile_lock_stacks_link = find('.modal-content a')
-    gemfile_lock_stacks_url = gemfile_lock_stacks_link['href']
-    expect(gemfile_lock_stacks_url.end_with?("/file/#{druid}/Gemfile.lock")).to be true
+    retries_count = 0
+    begin
+      # Download Gemfile.lock (shelve=true) from Stacks
+      click_link_or_button 'Gemfile.lock'
+      expect(page).to have_text 'Stacks:'
+      gemfile_lock_stacks_link = find('.modal-content a')
+      gemfile_lock_stacks_url = gemfile_lock_stacks_link['href']
+      gemfile_lock_stacks_link_text = gemfile_lock_stacks_link.text
+      expect(gemfile_lock_stacks_url.end_with?("/file/#{druid}/Gemfile.lock")).to be true
 
-    click_link_or_button gemfile_lock_stacks_link.text
+      puts "about to click on '#{gemfile_lock_stacks_link_text}' to get '#{gemfile_lock_stacks_url}'"
+      click_link_or_button gemfile_lock_stacks_link_text
+      if page.has_content?('Expected a successful response from the server, but got an error')
+        raise 'Error opening opening file modal'
+      end
+    rescue StandardError => e
+      puts "download attempt failed (link click text=#{gemfile_lock_stacks_link_text}): #{e.class}; #{e.inspect}; #{e}"
+
+      puts "sleeping and retrying (retries_count=#{retries_count})"
+      sleep 10
+      retries_count += 1
+      if retries_count < 5
+        visit "#{start_url}/view/#{druid}"
+        retry
+      end
+    end
     wait_for_download
 
     click_link_or_button 'Cancel'
@@ -89,13 +125,26 @@ RSpec.describe 'SDR deposit' do
     page.execute_script "document.querySelector('.modal-content a').href = '#{gemfile_pres_url.sub('Gemfile',
                                                                                                    'Gemfile.lock')}'"
     gemfile_pres_link = find('.modal-content a')
+    gemfile_pres_link_text = gemfile_pres_link.text
     expect(gemfile_pres_link['href'].end_with?("/items/#{druid}/files/Gemfile.lock/preserved?version=1")).to be true
 
-    click_link_or_button gemfile_pres_link.text
-    # This file is downloaded, but contain a 404 error message. (This is just how Argo currently operates.)
-    expect(download_content).to include '404 Not Found'
+    puts "about to click on '#{gemfile_pres_link_text}' to get '#{gemfile_pres_url}'"
+    download_error = nil
+    begin
+      click_link_or_button gemfile_pres_link.text
+    rescue Selenium::WebDriver::Error::WebDriverError => e
+      puts "download attempt failed (link click text=#{gemfile_pres_link_text}): #{e.class}; #{e.inspect}; #{e}"
+      download_error = e
+    end
 
-    click_link_or_button 'Cancel'
+    if download_error.present?
+      expect(download_error.to_s).to include('Reached error page: about:neterror?e=fileNotFound')
+      visit "#{start_url}/view/#{druid}"
+    else
+      # This file is downloaded, but contain a 404 error message. (This is just how Argo currently operates.)
+      expect(download_content).to include '404 Not Found'
+      click_link_or_button 'Cancel'
+    end
 
     # Try to download Gemfile (shelve=false) from Stacks
     click_link_or_button 'Gemfile.lock'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,8 +60,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  # cribbed from https://gist.github.com/osulyanov/10609515 and https://rspec.info/documentation/3.13/rspec-core/RSpec/Core/Example.html
-  # we may have used this in the past, but it had no commits in 4 years as of 2025: https://github.com/mattheworiordan/capybara-screenshot
+  # When a test fails, try to take a screenshot of the page right after the failure, and print the URL where the failure occurred
+  #
+  # Cribbed from https://gist.github.com/osulyanov/10609515 and https://rspec.info/documentation/3.13/rspec-core/RSpec/Core/Example.html
+  # We may have used this gem in the past, but it had no commits in 4 years as of feb 2025: https://github.com/mattheworiordan/capybara-screenshot
   config.after do |example|
     if example.exception.present?
       filename = File.basename(example.file_path).sub(/.rb$/, '') # /foo/bar.rb -> bar

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,23 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # cribbed from https://gist.github.com/osulyanov/10609515 and https://rspec.info/documentation/3.13/rspec-core/RSpec/Core/Example.html
+  # we may have used this in the past, but it had no commits in 4 years as of 2025: https://github.com/mattheworiordan/capybara-screenshot
+  config.after do |example|
+    if example.exception.present?
+      filename = File.basename(example.file_path).sub(/.rb$/, '') # /foo/bar.rb -> bar
+      line_number = example.location.match(/:(\d+)$/)&.match(1) # ./path/to/spec.rb:17 -> 17
+      screenshot_name = "failure-auto-screenshot-#{DateTime.now.strftime('%Y%m%d-%H%M%S')}-#{filename}-#{line_number}.png"
+      screenshot_path = "tmp/#{screenshot_name}"
+
+      page.save_screenshot(screenshot_path) # rubocop:disable Lint/Debugger
+
+      puts "📸 '#{example.full_description}' failed. Screenshot: #{screenshot_path}"
+    end
+  rescue StandardError => e
+    puts "⚠️ error taking screenshot for failed test: #{e}"
+  end
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
 
       page.save_screenshot(screenshot_path) # rubocop:disable Lint/Debugger
 
-      puts "📸 '#{example.full_description}' failed. Screenshot: #{screenshot_path}"
+      puts "📸 '#{example.full_description}' failed (url: '#{page.current_url}'). Screenshot: #{screenshot_path}"
     end
   rescue StandardError => e
     puts "⚠️ error taking screenshot for failed test: #{e}"

--- a/spec/support/download_helpers.rb
+++ b/spec/support/download_helpers.rb
@@ -20,7 +20,8 @@ module DownloadHelpers
   end
 
   def wait_for_download
-    Timeout.timeout(TIMEOUT) do
+    # raising StandardError with a helpful message makes failure reporting nicer
+    Timeout.timeout(TIMEOUT, StandardError, 'timed out waiting for download') do
       sleep 0.1 until downloaded?
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

file system lag (?) made `sdr_deposit_spec` almost unusable for me otherwise this week.

## Was README.md updated if necessary? 🤨

since the console output prints the info about the screenshot fairly prominently, and since the screenshotting isn't configurable in this version of the PR, it didn't seem necessary to adjust the readme.  but i'm of course happy to add to the readme for this PR as-is if that's desired, and/or to make the screenshotting behavior configurable (e.g. enabled via setting, with whatever default people prefer).
