### PR TITLE
Switch to debug to follow our standard practices moving away from byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,15 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport'
-gem 'byebug'
 gem 'capybara'
 gem 'capybara_table'
 gem 'config'
 gem 'csv'
+gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'
 gem 'dor-services-client'
 gem 'druid-tools' # for constructing druid tree strings easily
 gem 'faker'
 gem 'faraday' # etds require POST request from registrar
-gem 'pry-byebug'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,6 @@ GEM
     base64 (0.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
-    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -51,13 +50,16 @@ GEM
       super_diff
       thor
       zeitwerk (~> 2.1)
-    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     config (5.5.2)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
     connection_pool (2.5.0)
     csv (3.3.2)
+    date (3.4.1)
+    debug (1.10.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     deep_merge (1.2.2)
     deprecation (1.1.0)
       activesupport
@@ -114,6 +116,11 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.10.1)
     jsonpath (1.1.5)
       multi_json
@@ -125,7 +132,6 @@ GEM
     lint_roller (1.1.0)
     logger (1.6.6)
     matrix (0.4.2)
-    method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
@@ -148,12 +154,12 @@ GEM
       racc
     patience_diff (1.2.0)
       optimist (~> 3.0)
-    pry (0.14.2)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (3.1.10)
@@ -161,7 +167,11 @@ GEM
       rack (>= 1.3)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.12.0)
+      psych (>= 4.0.0)
     regexp_parser (2.10.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rexml (3.4.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -222,6 +232,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    stringio (3.1.5)
     super_diff (0.15.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -248,16 +259,15 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  byebug
   capybara
   capybara_table
   config
   csv
+  debug
   dor-services-client
   druid-tools
   faker
   faraday
-  pry-byebug
   rake
   rspec
   rubocop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require 'byebug'
 require 'config'
 require 'csv'
+require 'debug'
 require 'faker'
 require 'io/console'
-require 'pry-byebug'
 require 'rubyXL'
 require 'sdr_client'
 require 'selenium-webdriver'


### PR DESCRIPTION
## Why was this change made? 🤔

This is a small housekeeping PR that resolves the deprecation warning below related to `byebug` and we mostly use `debug` throughout our repos now.

```
/Users/amcollie/.rbenv/versions/3.4.1/lib/ruby/3.4.0/readline.rb:4: warning: reline was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add reline to your Gemfile or gemspec to silence this warning.
/Users/amcollie/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/byebug-11.1.3/lib/byebug/commands/irb.rb:4: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
```

## Was README.md updated if necessary? 🤨


