### PR TITLE
H3 globus auth click thru n rubocop touchups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -592,3 +592,36 @@ Style/HashSlice: # new in 1.71
   Enabled: true
 Style/ItAssignment: # new in 1.70
   Enabled: true
+
+Gemspec/AttributeAssignment: # new in 1.77
+  Enabled: true
+Lint/CopDirectiveSyntax: # new in 1.72
+  Enabled: true
+Lint/RedundantTypeConversion: # new in 1.72
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion: # new in 1.72
+  Enabled: true
+Lint/UselessConstantScoping: # new in 1.72
+  Enabled: true
+Lint/UselessDefaultValueArgument: # new in 1.76
+  Enabled: true
+Lint/UselessOr: # new in 1.76
+  Enabled: true
+Style/CollectionQuerying: # new in 1.77
+  Enabled: true
+Style/ComparableBetween: # new in 1.74
+  Enabled: true
+Style/EmptyStringInsideInterpolation: # new in 1.76
+  Enabled: true
+Style/HashFetchChain: # new in 1.75
+  Enabled: true
+Style/ItBlockParameter: # new in 1.75
+  Enabled: true
+Style/RedundantArrayFlatten: # new in 1.76
+  Enabled: true
+Style/RedundantFormat: # new in 1.72
+  Enabled: true
+Capybara/FindAllFirst: # new in 2.22
+  Enabled: true
+RSpec/IncludeExamples: # new in 3.6
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rake

--- a/spec/features/h3_globus_creation_spec.rb
+++ b/spec/features/h3_globus_creation_spec.rb
@@ -56,6 +56,9 @@ RSpec.describe 'Use H3 to create a collection and an item object belonging to it
       # select upload button
       find('span', text: 'Upload').click
 
+      click_link_or_button 'Continue' if page.has_text? 'Authentication/Consent is required'
+      click_link_or_button 'Allow' if page.has_text? 'Globus Web App would like to'
+
       # Attaching file directly to the upload-files input
       attach_file('upload-files', "spec/fixtures/#{filename}", make_visible: true)
 


### PR DESCRIPTION
## Why was this change made? 🤔

* this got me through some dialogs i got on both QA and stage.  worked on subsequent runs even after the initial accpetances made it so the prompts weren't shown again.
* good to stay up to date (though i will admit i declined to add `Naming/PredicateMethod` and `Capybara/NegationMatcherAfterVisit` because the fixes, esp for the latter, didn't seem totally mindless/trivial -- i'm happy to ticket if people think that's a good idea)

## Was README.md updated if necessary? 🤨

n/a