### PR TITLE
tiny hack to presumably give time for all the expected page elements to render before looking for them, to avoid potentially undercounting

### DIFF
--- a/spec/features/sdr_deposit_spec.rb
+++ b/spec/features/sdr_deposit_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'SDR deposit' do
     # Tests existence of technical metadata
     expect(page).to have_text 'Technical metadata'
     click_link_or_button 'Technical metadata'
+    sleep(5)
 
     # this is a hack that forces the techMD section to scroll into view; the section
     # is lazily loaded, and won't actually be requested otherwise, even if the button


### PR DESCRIPTION
## Why was this change made? 🤔

before adding this hack, `sdr_deposit_spec.rb` was failing for me very consistently this afternoon, as follows:

```
Failures:

  1) SDR deposit deposits objects
     Failure/Error: expect(file_listing.size).to eq 2
     
       expected: 2
            got: 1
     
       (compared using ==)
     # ./spec/features/sdr_deposit_spec.rb:55:in 'block (3 levels) in <top (required)>'
     # ./spec/features/sdr_deposit_spec.rb:52:in 'block (2 levels) in <top (required)>'
```

and in watching the automated browser, or looking at the failure screenshot, i could indeed see only one file listed in the section.  but every time i visited the page for the test druid myself, even if i did it before the spec got to the aforementioned failing test, i'd see two files.  i could `sleep(60)` before opening the techMD section, and there's already a check before that section is opened to ensure status is `v1 Accessioned`.  that's all to say, i don't think this one is lag in the service, i think it's a quirk of the `find_all('.file')` call only counting things that are already rendered, and not waiting at all for the page to further render, like other capybara DOM querying methods do.

other stray observations:
* never ran into this problem before today
* didn't run into this issue with other tests, including ones that expand the event section to look for replication events, though iirc the DOM part of that check is pretty cursory and the real thorough event checking is done by using dor-services-client to make a REST call to get the event list for the druid
* this afternoon, before testing, i did update my firefox installation that's used for integration test running, so maybe this is a browser quirk

## Was README.md updated if necessary? 🤨


