### PR TITLE
Remove references to dependency that is no longer present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'rubocop-rspec_rails'
 gem 'rubyXL' # for updating Excel spreadsheets
 gem 'sdr-client', '~> 2.0'
 gem 'selenium-webdriver'
-gem 'websocket' # required by selenium-webdrivers; a ruby upgrade somehow obscured this dependency
+gem 'websocket' # required by selenium-webdriver; a ruby upgrade somehow obscured this dependency

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The tests use Ruby 3.4.
 The tests depend on having Firefox (default) or Chrome downloaded.
 
 1. `bundle install`
-1. `bin/rake webdrivers:geckodriver:update`
 
 See the `Other Configuration` section below for
 - instructions on using Chrome
@@ -125,7 +124,6 @@ If you tire of typing in your SUNet credentials over and over, you may add them 
 ### Use Chrome Browser
 
 1. `bundle install`
-1. `bin/rake webdrivers:chromedriver:update`
 1. Set `browser.driver` to `chrome` in `config/settings.local.yml`
 
 ### Change Browser Window Size

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'webdrivers'
-load 'webdrivers/Rakefile'
-
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 


### PR DESCRIPTION
# Why was this change made?

`bin/rake` was broken and the README was misleading.

# Was README.md updated if necessary?

Yes.
