### PR TITLE
Workflow retry hijinks

### DIFF
--- a/spec/features/h3_object_creation_spec.rb
+++ b/spec/features/h3_object_creation_spec.rb
@@ -141,11 +141,19 @@ RSpec.describe 'Use H3 to create a collection and an item object belonging to it
     # Opens Argo detail page
     visit "#{Settings.argo_url}/view/#{work_druid}"
     # wait for accessioningWF to finish; retry if error on shelving step, likely caused by a race condition
-    workflow_retry_text = /(Error: shelve : problem with shelve)|(start-accession : druid:.* not found in Preservation)/
     reload_page_until_timeout_with_wf_step_retry!(expected_text: 'v3 Accessioned',
-                                                  workflow: 'accessionWF',
-                                                  workflow_retry_text:,
-                                                  retry_wait: 10)
+                                                  workflow: nil,
+                                                  retry_wait: 10) do |page|
+      if page.has_text?('v3 Accessioned')
+        next true # done retrying, success
+      elsif page.has_text?(/(Error: shelve : problem with shelve)|(start-accession : druid:.* not found in Preservation)/, wait: 1) # rubocop:disable Layout/LineLength
+        next 'accessionWF' # these messages are for accessionWF steps
+      elsif page.has_text?(/transfer-object : Error transferring bag .* for druid:/, wait: 1)
+        next 'preservationIngestWF' # this message is for a preservationIngestWF step
+      else
+        next false # unexpected error message, will keep retrying with the last retried workflow
+      end
+    end
     expect(page).to have_text('adding a file (Public version 2)') # now we are on user version 2 since we added a file
     expect(page).to have_no_text('Public version 3') # and no user version 3
     expect_text_on_purl_page(druid: work_druid, text: 'Version 2') # PURL now shows user version 2

--- a/spec/features/h3_object_creation_spec.rb
+++ b/spec/features/h3_object_creation_spec.rb
@@ -141,9 +141,10 @@ RSpec.describe 'Use H3 to create a collection and an item object belonging to it
     # Opens Argo detail page
     visit "#{Settings.argo_url}/view/#{work_druid}"
     # wait for accessioningWF to finish; retry if error on shelving step, likely caused by a race condition
+    workflow_retry_text = /(Error: shelve : problem with shelve)|(start-accession : druid:.* not found in Preservation)/
     reload_page_until_timeout_with_wf_step_retry!(expected_text: 'v3 Accessioned',
                                                   workflow: 'accessionWF',
-                                                  workflow_retry_text: 'Error: shelve : problem with shelve',
+                                                  workflow_retry_text:,
                                                   retry_wait: 10)
     expect(page).to have_text('adding a file (Public version 2)') # now we are on user version 2 since we added a file
     expect(page).to have_no_text('Public version 3') # and no user version 3

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -16,21 +16,35 @@ module PageHelpers
   end
 
   # Some workflow steps fail due to race conditions or other temporary annoyances.
-  # This method provides a way to retry a workflow step if the workflow fails with a specific error message.
+  #
+  # This method provides a way to retry the last errored step in the specified workflow when there's an alert matching
+  # workflow_retry_text.
   # It will stop retrying when the passed in block returns true, or if no block is given, when
-  # workflow_retry_text is found in the page.
+  # expected_text is found in the page.
+  # Bonus feature/complication: if the block returns a String instead of true or false, that string will be used to
+  # choose which workflow is clicked into to reset the last step.  o_O
+  #
   # @param expected_text [String,Regexp] the text that will end the refresh loop, if present and no block is provided.
   # @param workflow [String] the workflow in which a step may need to be retried
   # @param workflow_retry_text [String,Regexp] alert text that'll trigger retry of the last failed step of the specified workflow
+  #
   # @yieldparam page [Capybara::Node::Document] the currrent page, from which we're retrying the workflow
-  # @yieldreturn [boolean] done retrying the workflow if true, otherwise continue
-  def reload_page_until_timeout_with_wf_step_retry!(expected_text: '',
+  # @yieldreturn [boolean,String] done retrying the workflow if true, otherwise continue. if a String, override workflow param
+  def reload_page_until_timeout_with_wf_step_retry!(expected_text: '', # rubocop:disable Metrics/MethodLength
                                                     workflow: 'accessionWF',
                                                     workflow_retry_text: '',
                                                     retry_wait: 5)
     Timeout.timeout(Settings.timeouts.workflow) do
       loop do
-        break if block_given? ? yield(page) : page.has_text?(expected_text, wait: 1)
+        # break if block_given? ? yield(page) : page.has_text?(expected_text, wait: 1)
+        if block_given?
+          yield_val = yield(page)
+          break if yield_val == true
+
+          workflow = yield_val if yield_val.is_a?(String)
+        else
+          break if page.has_text?(expected_text, wait: 1)
+        end
 
         if page.has_css?('.alert-danger', wait: 0) && page.has_text?(workflow_retry_text)
           click_link_or_button workflow

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -19,6 +19,9 @@ module PageHelpers
   # This method provides a way to retry a workflow step if the workflow fails with a specific error message.
   # It will stop retrying when the passed in block returns true, or if no block is given, when
   # workflow_retry_text is found in the page.
+  # @param expected_text [String,Regexp] the text that will end the refresh loop, if present and no block is provided.
+  # @param workflow [String] the workflow in which a step may need to be retried
+  # @param workflow_retry_text [String,Regexp] alert text that'll trigger retry of the last failed step of the specified workflow
   # @yieldparam page [Capybara::Node::Document] the currrent page, from which we're retrying the workflow
   # @yieldreturn [boolean] done retrying the workflow if true, otherwise continue
   def reload_page_until_timeout_with_wf_step_retry!(expected_text: '',


### PR DESCRIPTION
## Why was this change made? 🤔

More reliable integration tests that need slightly less nudging and babysitting.  See below for example error addressed by this PR.

To test, I re-ran the whole suite.  I still had to re-run a number of failed tests individually.  But without the changes in this PR, I also had to babysit and use another browser to manually retry the workflow steps that this PR auto-retries. (I still had to do that occasionally for a couple H2 specs, but I figured those would be retired soon, and so didn't bother fixing them up)

I assume the first commit won't be that controversial.

The second commit adds a mechanism for workflow step retry that is more flexible than current `main`, and backwards compatible with existing usage.  It also feels a little weird and hacky, esp with the return type examination.  I'm very open to other approaches.

One other approach I can think of would be to build more knowledge into the workflow retry method of which steps and error messages go with which workflows.  But personally, whatever we do, I'd be more comfortable with an approach that continues to require the test to list out expected workflow steps and error messages that indicate a need for retry, as opposed to something that just retries the last failed workflow step when one is detected.  That way, at least a couple people (the PR author and the reviewer) are aware of a flaky workflow step, race condition, etc when a new retry is added to the integration tests.

### example error addressed by this PR

before the changes in the second commit, i was running into a number of errors along the lines of 

```
*** h3 work creation druid: druid:hx186fz6956 ***
📸 'Use H3 to create a collection and an item object belonging to it and version it is expected to have no css ".alert-danger" and {wait: 0}' failed (url: 'https://argo-stage.stanford.edu/view/druid:hx186fz6956'). Screenshot: tmp/failure-auto-screenshot-20250729-224330-h3_object_creation_spec-12.png
  is expected to have no css ".alert-danger" and {wait: 0} (FAILED - 1)

Failures:

  1) Use H3 to create a collection and an item object belonging to it and version it is expected to have no css ".alert-danger" and {wait: 0}
     Failure/Error:
           Timeout.timeout(Settings.timeouts.workflow) do
             loop do
               break if block_given? ? yield(page) : page.has_text?(expected_text, wait: 1)
       
               if page.has_css?('.alert-danger', wait: 0) && page.has_text?(workflow_retry_text)
                 click_link_or_button workflow
                 select 'Rerun', from: 'status'
                 confirm_message = 'You have selected to manually change the status. '
                 confirm_message += 'This could result in processing errors. Are you sure you want to proceed?'
                 accept_confirm(confirm_message) do
     
     Timeout::Error:
       execution expired
     # ./spec/support/page_helpers.rb:31:in 'PageHelpers#reload_page_until_timeout_with_wf_step_retry!'
     # ./spec/features/h3_object_creation_spec.rb:145:in 'block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Timeout::ExitException:
     #   execution expired
     #   ./spec/support/page_helpers.rb:35:in 'block (2 levels) in PageHelpers#reload_page_until_timeout_with_wf_step_retry!'
```

the error in that case was `preservationIngestWF` -- `transfer-object : Error transferring bag (via /dor/export/) for druid:hx186fz6956: /dor/export/hx186fz6956/data/metadata/versionMetadata.xml not found`.

## Was README.md updated if necessary? 🤨

n/a