### PR TITLE
Only check image URL not canvas id in IIIF manifest

### DIFF
--- a/spec/features/goobi_accessioning_spec.rb
+++ b/spec/features/goobi_accessioning_spec.rb
@@ -112,9 +112,7 @@ RSpec.describe 'Create and accession object via Goobi', if: $sdr_env == 'stage' 
                              href: "#{Settings.searchworks_url}/view/#{bare_object_druid}")
     iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
     iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
-    canvas_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, '@id')
-    canvas = JSON.parse(Faraday.get(canvas_url).body)
-    image_url = canvas.dig('images', 0, 'resource', '@id')
+    image_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, 'images', 0, 'resource', '@id')
     image_response = Faraday.get(image_url)
     expect(image_response.status).to eq(200)
     expect(image_response.headers['content-type']).to include('image/jpeg')

--- a/spec/features/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly_ocr_image_spec.rb
@@ -158,9 +158,7 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
     expect_text_on_purl_page(druid:, text: object_label)
     iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
     iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
-    canvas_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, '@id')
-    canvas = JSON.parse(Faraday.get(canvas_url).body)
-    image_url = canvas.dig('images', 0, 'resource', '@id')
+    image_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, 'images', 0, 'resource', '@id')
     image_response = Faraday.get(image_url)
     expect(image_response.status).to eq(200)
     expect(image_response.headers['content-type']).to include('image/jpeg')

--- a/spec/features/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly_reaccessioning_spec.rb
@@ -273,9 +273,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
     expect_text_on_purl_page(druid:, text: object_label)
     iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
     iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
-    canvas_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, '@id')
-    canvas = JSON.parse(Faraday.get(canvas_url).body)
-    image_url = canvas.dig('images', 0, 'resource', '@id')
+    image_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, 'images', 0, 'resource', '@id')
 
     # In late August 2025, during a versioning work cycle on the Access side, we
     # started noticing that the image URL returned a 404 initially but


### PR DESCRIPTION
## Why was this change made? 🤔
We started getting errors when trying to access the canvas id URL in IIIF manifests. This is no longer intended to be resolvable, so we should just check the image URL works. 
