### PR TITLE
preassembly_reaccessioning_spec.rb confirms replicated copy is retrievable and passes checksum validation

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,6 +60,9 @@ preassembly:
   gis_bundle_directory: '/dor/staging/integration-tests/gis-test'
   virtual_object_bundle_directory: '/dor/staging/integration-tests/virtual-object-test'
 
+preservation_catalog:
+  username: 'pres'
+
 earthworks_url: 'https://earthworks-stage.stanford.edu/catalog'
 
 ocr:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -6,6 +6,8 @@ h3_url: 'https://sul-h3-qa.stanford.edu'
 preassembly:
   host: 'sul-preassembly-qa.stanford.edu'
   url: 'https://sul-preassembly-qa.stanford.edu'
+preservation_catalog:
+  host: 'preservation-catalog-worker-qa-01'
 sdrapi_url: 'https://sdr-api-qa.stanford.edu'
 was_playback_url: 'https://swap-qa.stanford.edu'
 was_registrar:

--- a/config/settings/stage.yml
+++ b/config/settings/stage.yml
@@ -6,6 +6,8 @@ h3_url: 'https://sul-h3-stage.stanford.edu'
 preassembly:
   host: 'sul-preassembly-stage.stanford.edu'
   url: 'https://sul-preassembly-stage.stanford.edu'
+preservation_catalog:
+  host: 'preservation-catalog-worker-stage-01'
 sdrapi_url: 'https://sdr-api-stage.stanford.edu'
 was_playback_url: 'https://swap-stage.stanford.edu'
 was_registrar:

--- a/spec/features/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly_reaccessioning_spec.rb
@@ -296,5 +296,6 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly' do
 
     visit_argo_and_confirm_event_display!(druid:, version: latest_version)
     confirm_archive_zip_replication_events!(druid:, from_version: 1, to_version: latest_version)
+    retrieve_and_fixity_check_replicated_druid!(bare_druid:, expected_version: latest_version)
   end
 end

--- a/spec/support/preservation_helpers.rb
+++ b/spec/support/preservation_helpers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PreservationHelpers
+  def retrieve_and_fixity_check_replicated_druid!(bare_druid:, expected_version:)
+    fixity_check_cmd = 'cd preservation_catalog/current && RAILS_ENV=production bin/fixity_check_replicated_moabs ' \
+                       "--druid_list #{bare_druid} --endpoints_to_audit gcp_s3_south_1"
+    remote_destination = "#{Settings.preservation_catalog.username}@#{Settings.preservation_catalog.host}"
+    remote_fixity_check_cmd = "ssh #{remote_destination} '#{fixity_check_cmd}'"
+    stdout_str, stderr_str, status =
+      begin
+        Open3.capture3(remote_fixity_check_cmd)
+      rescue StandardError => e
+        puts "Error executing system command: '#{remote_fixity_check_cmd}' raised #{e}"
+      end
+
+    cmd_result = {
+      cmd: remote_fixity_check_cmd, stdout_str:, stderr_str:, exitstatus: status.exitstatus, success: status.success?
+    }
+    puts cmd_result
+    expect(cmd_result[:exitstatus]).to eq 0
+    expect(cmd_result[:success]).to be true
+    expect(stdout_str).to match(/fixity check passed - validate_checksums - #{bare_druid}.*actual version: #{expected_version}/)
+  end
+end
+
+RSpec.configure { |config| config.include PreservationHelpers }


### PR DESCRIPTION
uses preservation_catalog's `bin/fixity_check_replicated_moabs` script to confirm cloud archive is retrievable (from at least one endpoint) and complete/correct (_NOTE_: depends on https://github.com/sul-dlss/preservation_catalog/pull/2530)

## Why was this change made? 🤔

More complete automated end to end testing.

Shouldn't add much time since it's one test, and the Moab being retrieved and validated is small.

## Was README.md updated if necessary? 🤨

n/a