### PR TITLE
[SPIKE] add basic Word Error Rate check to preassembly_speech_to_text_media_spec.rb

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Project Guidelines
+
+infrastructure-integration-test is a suite of feature specs that drive a browser, mostly to interact with user facing SDR applications, occasionally to interact with SDR via command line tools such as `ssh`. The intent is to simulate realistic SDR usage scenarios, and to exercise as much of the core SDR functionality as possible. Compared to unit tests within the various SDR applications, the focus here is on interacting with deployed applications, especially in ways that cross service boundaries, to verify that our own applications are interacting successfully with each other, and with external services such as cloud compute and storage. This allows us to confirm that code changes work as intended and do not introduce new bugs.
+
+## Architecture
+
+The test suite uses Capybara feature specs to drive a browser, on a developer laptop, against SDR applications. The test suite uses the browser to do things such as accessioning and versioning objects of different types. This is done through many different applications, including but not limited to: Preassembly, Argo, H3 (hungry-hungry-hippo, the self deposit app). There are also interactions via the command-line with sdr-api and dor-services-app, mostly to stage or update content, but sometimes to check the state of something, to confirm operation as expected.
+
+## Testing Notes
+
+Sometimes a test fails because the UI has changed compared to the most recent test expectations. In this case, the test should be updated.
+
+Sometimes a test fails because it has caught a bug introduced by a code change. Typically, the correct thing to do is to fix the bug. Sometimes, the correct thing to do is to temporarily ignore the test failure or to temporarily comment out the expectation.
+
+Sometimes a test fails because Capybara driven interactions with the browser can be flaky, possibly because of Capybara having trouble detecting DOM mutations. In this case, the test should be re-run for as long as it looks like the failures are due to flakiness.
+
+Sometimes a test fails because of networking issues, possibly from the test suite to the applications and services it's interacting with, possibly between SDR services that interact to provide users with functionality. In this case, a developer should inquire with ops if it looks like the issue is previously undetected inter-service connection trouble. The developer should troubleshoot their network connection if it seems the issue is between the laptop running the test suite, and the rest of the world.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,6 @@ gem 'rubocop-rspec_rails'
 gem 'rubyXL' # for updating Excel spreadsheets
 gem 'sdr-client', '~> 2.0'
 gem 'selenium-webdriver'
+gem 'amatch'
+gem 'webvtt-ruby'
 gem 'websocket' # required by selenium-webdriver; a ruby upgrade somehow obscured this dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,9 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    amatch (0.6.0)
+      mize
+      tins (~> 1)
     ast (2.4.3)
     attr_extras (7.1.0)
     base64 (0.3.0)
@@ -144,16 +147,13 @@ GEM
     logger (1.7.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    mize (0.6.1)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.3)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-darwin)
@@ -186,6 +186,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    readline (0.0.4)
+      reline
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -259,9 +261,15 @@ GEM
       attr_extras (>= 6.2.4, < 8)
       diff-lcs (~> 1.5)
       patience_diff (~> 1.2)
+    sync (0.5.0)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
+    tins (1.54.0)
+      bigdecimal
+      mize (~> 0.6)
+      readline
+      sync
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -270,19 +278,20 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     websocket (1.2.11)
+    webvtt-ruby (0.4.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.8.2)
 
 PLATFORMS
   arm64-darwin
-  ruby
   x86_64-darwin-19
   x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
   activesupport
+  amatch
   capybara
   capybara_table
   config
@@ -304,6 +313,7 @@ DEPENDENCIES
   sdr-client (~> 2.0)
   selenium-webdriver
   websocket
+  webvtt-ruby
 
 BUNDLED WITH
   4.0.12

--- a/spec/features/preassembly_speech_to_text_media_spec.rb
+++ b/spec/features/preassembly_speech_to_text_media_spec.rb
@@ -150,8 +150,34 @@ RSpec.describe 'Create a media object via Pre-assembly and ask for it be speechT
 
     expect(files[10].text).to match(%r{video_log.txt text/plain 5\d* Bytes No role})
 
-    # TODO: Add expectations for the speech to text files when they are added to the object
-    #
+    # Download the generated transcription files and check their Word Error Rate (WER)
+    # against the human-validated reference files.
+    within(files[8]) { click_link_or_button 'audio_1_m4a.txt' }
+    # second link in the modal is the preservation download link, which should already
+    # be available (whereas the stacks link availability can lag accessioning a bit)
+    all('.modal-content a')[1].click
+    wait_for_download
+    txt_wer = calculate_wer('spec/fixtures/speech-to-text-reference-transcript.txt', download, format: :text)
+    puts " *** Word Error Rate (TXT): #{txt_wer} ***"
+    expect(txt_wer).to be < 0.05 # Allow for slight variations in ASR
+    delete_download(download)
+
+    # close the file modal
+    click_link_or_button 'Cancel'
+
+    within(files[9]) { click_link_or_button 'audio_1_m4a.vtt' }
+    # second link in the modal is the preservation download link, which should already
+    # be available (whereas the stacks link availability can lag accessioning a bit)
+    all('.modal-content a')[1].click
+    wait_for_download
+    vtt_wer = calculate_wer('spec/fixtures/speech-to-text-reference-transcript.vtt', download, format: :vtt)
+    puts " *** Word Error Rate (VTT): #{vtt_wer} ***"
+    expect(vtt_wer).to be < 0.05
+    delete_download(download)
+
+    # close the file modal
+    click_link_or_button 'Cancel'
+
     expect(find_table_cell_following(header_text: 'Content type').text).to eq('media') # filled in by accessioning
 
     # check technical metadata for all non-thumbnail files

--- a/spec/fixtures/speech-to-text-reference-transcript.txt
+++ b/spec/fixtures/speech-to-text-reference-transcript.txt
@@ -1,0 +1,46 @@
+I'll show you the Montana film. This film was shot August the 15th, 1950. It was taken in Great Falls, Montana by Nick Mariana.
+Immediately after we were notified of the sighting, we sent an intelligence man to get a first-hand report.
+My name is Nick Mariano. For the past six years I've been the general manager of a minor league
+baseball club called the electrics. We play out of Great Falls Montana and are a farm club of
+the Brooklyn Dodgers. On August 15th 1950 at Legion ballpark in Great Falls Montana after
+a couple of hours in the clubhouse office I went up into the grandstand to call the groundskeeper.
+As I reached the top of the stairway, I glanced northward to the tall Anaconda Copper Company smokestack to check the direction of the wind from the white smoke.
+Force of habit, I suppose, because our outfielders use it as an indicator on defensive play.
+As I looked up, I saw two silvery objects moving swiftly out of the northwest.
+They appeared to be moving directly south.
+The objects were very bright and about 10,000 feet in the air.
+They appeared to be of a bright shiny metal, like polished silver. Both were the same size
+and were traveling at the same rate of speed, which was much slower than the jets which
+shot by shortly after I filmed the discs. Suddenly they stopped. It was then I remembered
+the camera in the glove compartment of my car. I raced downstairs yelling for my secretary,
+Miss Virginia Ronnie. The distance from the top of the stairway to my car is about 60
+feet and I must have made that in about six jumps. I asked my secretary if she
+saw anything and she said yes, two silvery spheres. I unlocked the glove
+compartment of my car, took out the camera, turned the telephoto lens on the
+turret into position, set the camera at f-22, picked up the objects in the
+viewfinder and pressed the trigger. The discs appeared to be spinning like the
+at top and were about 50 feet across and about 50 yards apart.
+I could not see any exhaust, wings,
+or any kind of fuselage.
+There was no cabin, no odor, no sound,
+except I thought I heard a whooshing sound when
+I first saw them.
+As the film clicked through the camera,
+I could see the objects moving southeast
+behind the General Mills grain building and the black water
+tank directly south of the ballpark.
+I filmed the objects until they disappeared into the blue sky behind the water tank.
+This is the Montana film projected exactly as it was photographed. The objects are moving against a 25 to 28 mile an hour wind.
+This is the film in double frame or slow motion.
+A slight bounce in the movement of the objects as well as the tower is perceptible.
+This is due to the handheld camera.
+The film, analyzed frame by frame, shows the movement of the objects to be horizontal and steady.
+We will now vary the action and size of the objects and also stop the action from time to time for your study.
+We have just made a jump cut in the film to an enlarged size and reversed the action.
+You are now seeing the objects exactly as they were photographed, but from a closer perspective.
+Analysis reveals that the objects are not balloons nor any kind of known aircraft.
+The images are very different from those produced by any kind of birds at any distance.
+The shape, brightness, speed, rectilinear path, steady motion, and separation rule out
+various forms of optical atmospheric mirages or cloud reflections.
+Comprehensive analysis has eliminated meteors and other known natural phenomena.
+The possibility of airplane reflection has been carefully studied and ruled out.

--- a/spec/fixtures/speech-to-text-reference-transcript.vtt
+++ b/spec/fixtures/speech-to-text-reference-transcript.vtt
@@ -1,0 +1,281 @@
+WEBVTT
+
+00:10.560 --> 00:13.220
+I'll show you the Montana film. This film
+
+00:13.220 --> 00:16.820
+was shot August the 15th, 1950. It was
+
+00:16.820 --> 00:18.760
+taken in Great Falls, Montana by Nick
+
+00:18.760 --> 00:21.040
+Mariana. Immediately after we were
+
+00:21.040 --> 00:22.980
+notified of the sighting, we sent an
+
+00:22.980 --> 00:24.500
+intelligence man to get a first-hand
+
+00:24.500 --> 00:24.880
+report.
+
+00:28.100 --> 00:31.160
+My name is Nick Mariano. For the past six
+
+00:31.160 --> 00:33.100
+years I've been the general manager of a
+
+00:33.100 --> 00:34.820
+minor league baseball club called the
+
+00:34.820 --> 00:37.440
+electrics. We play out of Great Falls
+
+00:37.440 --> 00:39.500
+Montana and are a farm club of the
+
+00:39.500 --> 00:44.080
+Brooklyn Dodgers. On August 15th 1950 at
+
+00:44.080 --> 00:45.840
+Legion ballpark in Great Falls Montana
+
+00:45.840 --> 00:48.640
+after a couple of hours in the clubhouse
+
+00:48.640 --> 00:50.560
+office I went up into the grandstand to
+
+00:50.560 --> 00:53.200
+call the groundskeeper. As I reached the
+
+00:53.200 --> 00:55.260
+top of the stairway, I glanced northward
+
+00:55.260 --> 00:57.080
+to the tall Anaconda Copper Company
+
+00:57.080 --> 00:59.420
+smokestack to check the direction of the
+
+00:59.420 --> 01:01.820
+wind from the white smoke. Force of habit,
+
+01:01.840 --> 01:03.740
+I suppose, because our outfielders use it
+
+01:03.740 --> 01:06.660
+as an indicator on defensive play. As I
+
+01:06.660 --> 01:08.840
+looked up, I saw two silvery objects
+
+01:08.840 --> 01:12.180
+moving swiftly out of the northwest. They
+
+01:12.180 --> 01:15.360
+appeared to be moving directly south. The
+
+01:15.360 --> 01:17.700
+objects were very bright and about 10,000
+
+01:17.700 --> 01:20.640
+feet in the air. They appeared to be of a
+
+01:20.640 --> 01:23.240
+bright shiny metal, like polished silver.
+
+01:24.140 --> 01:26.380
+Both were the same size and were traveling
+
+01:26.380 --> 01:28.560
+at the same rate of speed, which was much
+
+01:28.560 --> 01:30.420
+slower than the jets which shot by shortly
+
+01:30.420 --> 01:33.120
+after I filmed the discs. Suddenly they
+
+01:33.120 --> 01:35.620
+stopped. It was then I remembered the
+
+01:35.620 --> 01:37.480
+camera in the glove compartment of my car.
+
+01:38.020 --> 01:40.140
+I raced downstairs yelling for my
+
+01:40.140 --> 01:42.600
+secretary, Miss Virginia Ronnie. The
+
+01:42.600 --> 01:44.240
+distance from the top of the stairway to
+
+01:44.240 --> 01:46.500
+my car is about 60 feet and I must have
+
+01:46.500 --> 01:49.660
+made that in about six jumps. I asked my
+
+01:49.660 --> 01:51.840
+secretary if she saw anything and she said
+
+01:51.840 --> 01:55.720
+yes, two silvery spheres. I unlocked the
+
+01:55.720 --> 01:58.200
+glove compartment of my car, took out the
+
+01:58.200 --> 02:00.480
+camera, turned the telephoto lens on the
+
+02:00.480 --> 02:03.260
+turret into position, set the camera at f
+
+02:03.260 --> 02:05.600
+-22, picked up the objects in the
+
+02:05.600 --> 02:08.760
+viewfinder and pressed the trigger. The
+
+02:08.760 --> 02:10.520
+discs appeared to be spinning like the at
+
+02:10.520 --> 02:13.080
+top and were about 50 feet across and
+
+02:13.080 --> 02:16.560
+about 50 yards apart. I could not see any
+
+02:16.560 --> 02:19.440
+exhaust, wings, or any kind of fuselage.
+
+02:19.920 --> 02:24.000
+There was no cabin, no odor, no sound,
+
+02:24.020 --> 02:25.800
+except I thought I heard a whooshing sound
+
+02:25.800 --> 02:29.700
+when I first saw them. As the film clicked
+
+02:29.700 --> 02:32.140
+through the camera, I could see the
+
+02:32.140 --> 02:34.040
+objects moving southeast behind the
+
+02:34.040 --> 02:36.740
+General Mills grain building and the black
+
+02:36.740 --> 02:38.880
+water tank directly south of the ballpark.
+
+02:38.880 --> 02:41.680
+I filmed the objects until they
+
+02:41.680 --> 02:44.280
+disappeared into the blue sky behind the
+
+02:44.280 --> 02:44.780
+water tank.
+
+03:08.880 --> 03:11.620
+This is the Montana film projected exactly
+
+03:11.620 --> 03:13.920
+as it was photographed. The objects are
+
+03:13.920 --> 03:16.300
+moving against a 25 to 28 mile an hour
+
+03:16.300 --> 03:16.620
+wind.
+
+03:19.880 --> 03:22.220
+This is the film in double frame or slow
+
+03:22.220 --> 03:25.900
+motion. A slight bounce in the movement of
+
+03:25.900 --> 03:27.660
+the objects as well as the tower is
+
+03:27.660 --> 03:30.460
+perceptible. This is due to the handheld
+
+03:30.460 --> 03:34.760
+camera. The film, analyzed frame by frame,
+
+03:35.020 --> 03:36.960
+shows the movement of the objects to be
+
+03:36.960 --> 03:38.380
+horizontal and steady.
+
+03:41.840 --> 03:44.600
+We will now vary the action and size of
+
+03:44.600 --> 03:47.300
+the objects and also stop the action from
+
+03:47.300 --> 03:51.880
+time to time for your study. We have just
+
+03:51.880 --> 03:54.180
+made a jump cut in the film to an enlarged
+
+03:54.180 --> 03:56.060
+size and reversed the action.
+
+04:02.240 --> 04:04.900
+You are now seeing the objects exactly as
+
+04:04.900 --> 04:06.880
+they were photographed, but from a closer
+
+04:06.880 --> 04:07.360
+perspective.
+
+04:14.100 --> 04:16.600
+Analysis reveals that the objects are not
+
+04:16.600 --> 04:19.540
+balloons nor any kind of known aircraft.
+
+04:22.220 --> 04:24.600
+The images are very different from those
+
+04:24.600 --> 04:26.700
+produced by any kind of birds at any
+
+04:26.700 --> 04:31.460
+distance. The shape, brightness, speed,
+
+04:31.600 --> 04:34.000
+rectilinear path, steady motion, and
+
+04:34.000 --> 04:36.540
+separation rule out various forms of
+
+04:36.540 --> 04:39.020
+optical atmospheric mirages or cloud
+
+04:39.020 --> 04:39.660
+reflections.
+
+04:43.360 --> 04:45.360
+Comprehensive analysis has eliminated
+
+04:45.360 --> 04:48.180
+meteors and other known natural phenomena.
+
+04:51.390 --> 04:53.780
+The possibility of airplane reflection has
+
+04:53.780 --> 04:56.320
+been carefully studied and ruled out.
+

--- a/spec/support/transcription_helpers.rb
+++ b/spec/support/transcription_helpers.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'amatch'
+require 'webvtt'
+
+module TranscriptionHelpers
+  # Calculates Word Error Rate (WER) by mapping each unique word to a single Unicode character.
+  # This "word-to-character mapping" allows the character-based Amatch C extension to perform
+  # accurate word-level Levenshtein distance calculations (where 1 word change = 1 edit).
+  def calculate_wer(reference_path, hypothesis_path, format: :text)
+    ref_words = load_and_normalize(reference_path, format)
+    hyp_words = load_and_normalize(hypothesis_path, format)
+
+    return 0.0 if ref_words.empty? && hyp_words.empty?
+    return 1.0 if ref_words.empty?
+
+    # Map words to unique characters so that word-level edits equal character-level edits
+    vocabulary = (ref_words + hyp_words).uniq
+    word_to_char = vocabulary.each_with_index.to_h { |word, i| [word, [i].pack('U')] }
+
+    ref_encoded = ref_words.map { |w| word_to_char[w] }.join
+    hyp_encoded = hyp_words.map { |w| word_to_char[w] }.join
+
+    Amatch::Levenshtein.new(ref_encoded).match(hyp_encoded).to_f / ref_words.size
+  end
+
+  private
+
+  def load_and_normalize(path, format)
+    text = format == :vtt ? extract_vtt_text(path) : File.read(path)
+    text.downcase.gsub(/[[:punct:]]/, '').split
+  end
+
+  def extract_vtt_text(path)
+    vtt = WebVTT.read(path)
+    vtt.cues.map(&:plain_text).join(' ')
+  end
+end
+
+RSpec.configure { |config| config.include TranscriptionHelpers }


### PR DESCRIPTION
- Introduce `amatch` and `webvtt-ruby` dependencies to support transcription quality assessment.
- Implement a word-to-character mapping strategy in `TranscriptionHelpers` to allow the character-based Amatch C extension to perform accurate word-level Levenshtein distance calculations (1 word change = 1 edit).
- Add VTT normalization to extract spoken text from WebVTT files, removing timestamps, metadata, and punctuation to ensure the WER calculation reflects actual recognition quality.
- Add reference/baseline txt and vtt files for WER calculation, given output from a new integration test run (reference transcriptions were obtained from https://argo-stage.stanford.edu/view/druid:ys535zt3073, a result of this integration test; transcripts were validated by @jmartin-sul watching the video and reading the txt, as well as watching the video with the vtt selected as the caption source)
- Add the `AGENTS.md` file (and a `CLAUDE.md` symlink to it) that Gemini used in helping write this PR

Written by pairing with Gemini CLI and tweaking its work.  In particular, it came up with the WER mapping trick to use the distance gem we'd already settled on, as well as the VTT normalization approach.

ref https://github.com/sul-dlss/speech-to-text/issues/90 --
> The integration test passes but it doesn't do much with the resulting transcript other than ensure it's there and looks like it's about the right size.

Here's one attempt at fixing that part of the problem.

## Why was this change made? 🤔

I had been worrying aloud lately about how we test model-based outputs on an ongoing basis in a meaningful way, and this seemed like a good opportunity to experiment with one relatively basic approach to the problem (and it was an opportunity to get some practice pairing with an AI agent on a somewhat unfamiliar problem space).

It doesn't seem like support for this in Ruby is great.  Another approach I considered (but didn't pursue) was using `uvx` to put a little Python script in this project, since the support for this sort of thing seems better in Python land (see e.g. [werpy](https://github.com/analyticsinmotion/werpy), a word error rate analysis package in Python).

I spent about a day on this at the end of last week, and I learned some things about Word Error Rate calculation, and WebVTT, and the related Ruby tooling for both, and got some Gemini practice.  So even if others see reasons this isn't a good idea and we close it, no big deal.

## Was README.md updated if necessary? 🤨


