### PR TITLE
temporarily skip GIS specs

### DIFF
--- a/spec/features/preassembly/preassembly_gis_raster_accessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_gis_raster_accessioning_spec.rb
@@ -5,7 +5,9 @@
 # Preassembly requires that files to be included in an object must be available on a mounted drive
 # To this end, files have been placed on Settings.gis.robots_content_root
 # NOTE: this spec will be skipped unless run on staging, since there is no geoserver-qa
-RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage', type: :preassembly do
+RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage',
+                                                     skip: 'Temporarily disabled: GIS specs are not expected to pass',
+                                                     type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_gis_raster_accessioning' }
     let(:title) { test_data[:title] }

--- a/spec/features/preassembly/preassembly_gis_vector_accessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_gis_vector_accessioning_spec.rb
@@ -5,7 +5,9 @@
 # Preassembly requires that files to be included in an object must be available on a mounted drive
 # To this end, files have been placed on Settings.gis.robots_content_root
 # NOTE: this spec will be skipped unless run on staging, since there is no geoserver-qa
-RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage', type: :preassembly do
+RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage',
+                                                     skip: 'Temporarily disabled: GIS specs are not expected to pass',
+                                                     type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_gis_vector_accessioning' }
     let(:title) { test_data[:title] }


### PR DESCRIPTION
## Why was this change made? 🤔

The GIS specs are failing in this workcycle.  This branch will let us skip them easily for now which speeds things up.
