### PR TITLE
fix out of date comment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,8 +137,6 @@ RSpec.configure do |config|
   #     --seed 1234
   # config.order = :random
   config.register_ordering(:global) do |examples|
-    # NOTE: Even though we exclude preassembly, we still need to include it in
-    # order for it to be picked up when run manually
     order = %i[registration accessioning sdr verify preassembly]
 
     grouped = examples.group_by { |ex| ex.metadata[:type] }


### PR DESCRIPTION
## Why was this change made? 🤔

Pre-assembly specs are no longer automatically excluded.
