### PR TITLE
More integration test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Each type of test can be run as a separate group with:
 bin/rspec --tag type:[registration|accessioning|sdr|verify]
 ```
 
+### Accessioning Quick Run
+
+To run a minimal end-to-end accessioning path (register an APO and collection, register all the standard test objects, accession a plain image object via Preassembly, then re-accession it) without the more time consuming H3/GIS/OCR/media accessioning specs, use the `sample_accession` tag:
+
+```
+bin/rspec --tag sample_accession
+```
+
+### Rerun
+
+If a run produces some failures, you can try and re-run just the latest failed examples with the command below.  This can be run again as needed.
+
+`bin/rspec --only-failures`
+
+Note that required ordering and dependencies may mean some specs still don't work, notably the re-accessioning test.  In other words, some tests depend on previous ones having succeeded.  So you may still need to start all over again.
+
 ### Preassembly tests
 
 To run just the preassembly tests (skipping the other types), use the type tag.
@@ -71,7 +87,7 @@ bin/rspec spec/features/preassembly/preassembly_gis_raster_accessioning_spec.rb 
 
 Note: `spec/features/preassembly/preassembly_reaccessioning_spec.rb` loads the druid saved by `spec/features/accessioning/preassembly_accessioning_spec.rb`, which in turn loads the druid saved by `spec/features/registration/03_register_objects_spec.rb`. Filtering to `--tag type:preassembly` skips both of those, so they must have already run successfully at least once the same day (e.g. via a plain `bin/rspec`, or `bin/rspec --tag type:accessioning` after registration has run) before running the reaccessioning spec on its own.
 
-### Currently depracated
+### Currently deprecated
 
 If you would prefer to run the tests one by one and be prompted to move on to the next one you can use the following (but you will be prompted to login with Duo for each test):
 

--- a/spec/features/accessioning/preassembly_accessioning_spec.rb
+++ b/spec/features/accessioning/preassembly_accessioning_spec.rb
@@ -4,7 +4,7 @@
 # Preassembly requires that files to be included in an object must be available on a mounted drive
 # To this end, files have been placed on Settings.preassembly.host at Settings.preassembly.bundle_directory
 # # This uses the preassembly_job_creation shared example.
-RSpec.describe 'Create a Pre-assembly job', type: :accessioning do
+RSpec.describe 'Create a Pre-assembly job', :sample_accession, type: :accessioning do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_accessioning' }
   end

--- a/spec/features/preassembly/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_reaccessioning_spec.rb
@@ -5,7 +5,7 @@ require 'druid-tools'
 # Integration: Argo, DSA, Preassembly, Purl
 # Preassembly requires that files to be included in an object must be available on a mounted drive
 # To this end, files have been placed on Settings.preassembly.host at Settings.preassembly.bundle_directory
-RSpec.describe 'Create and re-accession image object via Pre-assembly', type: :preassembly do
+RSpec.describe 'Create and re-accession image object via Pre-assembly', :sample_accession, type: :preassembly do
   let(:start_url) { "#{Settings.argo_url}/view/#{druid}" }
   let(:bare_druid) { druid.delete_prefix('druid:') }
   let(:druid) { test_data[:druid] }
@@ -53,7 +53,8 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly', type: :p
   end
 
   scenario do
-    expect(page).to have_text(/v\d+ Accessioned/)
+    # Ensure accessioning from pre-assembly job that create this object is done before we start the re-accessioning process.
+    reload_page_until_timeout!(text: /v\d+ Accessioned/)
 
     # Get the original version from the page
     elem = find_table_cell_following(header_text: 'Status')

--- a/spec/features/registration/01_apo_registration_spec.rb
+++ b/spec/features/registration/01_apo_registration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Use Argo to register an APO', type: :registration do
+RSpec.describe 'Use Argo to register an APO', :sample_accession, type: :registration do
   let(:apo_title) { "Integration Testing APO #{random_phrase}" }
   let(:start_url) { "#{Settings.argo_url}/apo/new" }
   let(:rights) { 'World' }

--- a/spec/features/registration/02_collection_registration_spec.rb
+++ b/spec/features/registration/02_collection_registration_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Integration: Argo, DSA
-RSpec.describe 'Use Argo to register a collection', type: :registration do
+RSpec.describe 'Use Argo to register a collection', :sample_accession, type: :registration do
   let(:collection_title) { random_phrase }
   let(:collection_abstract) { 'Created by https://github.com/sul-dlss/infrastructure-integration-test' }
   let(:start_url) { "#{Settings.argo_url}/view/#{test_apo[:druid]}" }

--- a/spec/features/registration/03_register_objects_spec.rb
+++ b/spec/features/registration/03_register_objects_spec.rb
@@ -2,7 +2,7 @@
 
 # Registers all of the expected objects for follow up tests
 # Utilizes the register_objects shared example
-RSpec.describe 'Register objects in Argo', type: :registration do
+RSpec.describe 'Register objects in Argo', :sample_accession, type: :registration do
   it_behaves_like 'an SDR object registion' do
     let(:spec_name) { 'access_indexing' }
   end

--- a/spec/features/sdr/web_archive_accessioning_spec.rb
+++ b/spec/features/sdr/web_archive_accessioning_spec.rb
@@ -76,6 +76,9 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     # Seed
     visit "#{Settings.argo_url}/registration"
     select 'Web Archive Seed Object APO', from: 'Admin Policy'
+    # The Collection options are repopulated via Turbo in response to the Admin Policy
+    # selection, so wait for the target option to actually be there before selecting it.
+    expect(page).to have_select('Collection', with_options: [collection_name])
     select collection_name, from: 'Collection'
     select 'wasSeedPreassemblyWF', from: 'Initial Workflow'
     select 'webarchive-seed', from: 'Content Type'

--- a/spec/support/shared_examples/register_objects.rb
+++ b/spec/support/shared_examples/register_objects.rb
@@ -35,6 +35,9 @@ RSpec.shared_examples 'an SDR object registion' do
 
   it 'uses Argo to register an object' do
     select apo_for_registration, from: 'Admin Policy'
+    # The Collection options are repopulated via Turbo in response to the Admin Policy
+    # selection, so wait for the target option to actually be there before selecting it.
+    expect(page).to have_select('Collection', with_options: [collection_for_registration])
     select collection_for_registration, from: 'Collection'
     select type, from: 'Content Type' if type
     select workflow, from: 'Initial Workflow' if workflow


### PR DESCRIPTION
## Why was this change made? 🤔

1. Indicate in README how to quickly re-run just the last failed specs (built into rspec, didn't know this).
2. Make selecting a collection when registering less flaky (account for collection drop-down populating dynamically when APO is selected).
3. Add the ability to quickly run a subset of accessioning specs, ignoring long running ones like OCR/captioning/GIS.  This is helpful if you want to just verify that the core accessioning pipeline is working relatively quickly.
4. Typo fixes

## Was README.md updated if necessary? 🤨

Yes.

Verified by running integration tests.

