### PR TITLE
Replace label with title in feature specs and shared examples

### DIFF
--- a/spec/features/accessioning/item_creation_with_folio_hrid_spec.rb
+++ b/spec/features/accessioning/item_creation_with_folio_hrid_spec.rb
@@ -8,29 +8,29 @@ RSpec.describe 'Use Argo to create an item object with a Folio instance HRID', t
   let(:test_data) { load_test_data(spec_name: 'item_creation_with_folio_hrid') }
   # rubocop:disable RSpec/InstanceVariable
   let(:folio_instance_hrid) { @initial_hrid }
-  let(:catalog_object_label) { @initial_label } # will be pulled from folio
+  let(:catalog_object_title) { @initial_title } # will be pulled from folio
   let(:folio_instance_hrid_updated) { @updated_hrid }
-  let(:catalog_object_label_updated) { @updated_label } # the updated label after we change the hrid
+  let(:catalog_object_title_updated) { @updated_title } # the updated title after we change the hrid
   # rubocop:enable RSpec/InstanceVariable
-  let(:catalog_label) { /A la francaise|The means to prosperity/ }
+  let(:catalog_title) { /A la francaise|The means to prosperity/ }
   let(:user_tag) { 'Some : UniqueTagValue' }
   let(:project) { 'Awesome Folio Project' }
 
   before do
     authenticate!(start_url:, expected_text:)
 
-    # This swaps the initial and updated hrid and label
+    # This swaps the initial and updated hrid and title
     # to allow the test to be rerun without registering a new object
     @initial_hrid = Settings.test_folio_instance_hrid
-    @initial_label = 'The means to prosperity'
+    @initial_title = 'The means to prosperity'
     @updated_hrid = 'a123'
-    @updated_label = 'A la francaise'
+    @updated_title = 'A la francaise'
 
     if page.has_content?('a123')
       @initial_hrid = 'a123'
-      @initial_label = 'A la francaise'
+      @initial_title = 'A la francaise'
       @updated_hrid = Settings.test_folio_instance_hrid
-      @updated_label = 'The means to prosperity'
+      @updated_title = 'The means to prosperity'
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe 'Use Argo to create an item object with a Folio instance HRID', t
     expect(page).to have_text(user_tag)
     expect(page).to have_text("Project : #{project}")
     expect(page).to have_text(folio_instance_hrid)
-    expect(page).to have_text(catalog_label) # this was pulled from folio, overwriting used entered label
+    expect(page).to have_text(catalog_title) # this was pulled from folio, overwriting used entered title
     expect(page).to have_text("Registered By : #{AuthenticationHelpers.username}")
 
     # edit folio_instance_hrid
@@ -51,7 +51,7 @@ RSpec.describe 'Use Argo to create an item object with a Folio instance HRID', t
     expect(page).to have_text(folio_instance_hrid_updated)
     click_link_or_button 'Manage description'
     click_link_or_button 'Refresh'
-    reload_page_until_timeout!(text: catalog_object_label_updated) # updated label pulled from folio for new HRID
+    reload_page_until_timeout!(text: catalog_object_title_updated) # updated title pulled from folio for new HRID
 
     # look for metadata source facet having an entry of Folio for this druid
     fill_in 'Search...', with: druid

--- a/spec/features/accessioning/virtual_object_creation_spec.rb
+++ b/spec/features/accessioning/virtual_object_creation_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe 'Use Argo to create a virtual object with constituent objects', t
     sleep 5
 
     # Create virtual object
-    virtual_object_label = random_phrase
-    virtual_object_druid = deposit_object(title: virtual_object_label, viewing_direction: 'left-to-right')
+    virtual_object_title = random_phrase
+    virtual_object_druid = deposit_object(title: virtual_object_title, viewing_direction: 'left-to-right')
     puts " *** virtual object druid: #{virtual_object_druid} ***" # useful for debugging
 
     # Create CSV: virtual_object_druid, constituent_druid, constituent_druid
@@ -156,7 +156,7 @@ RSpec.describe 'Use Argo to create a virtual object with constituent objects', t
       expect_link_on_purl_page(
         druid: constituent_druid,
         href: "#{Settings.purl_url}/#{virtual_object_druid.delete_prefix('druid:')}",
-        text: virtual_object_label
+        text: virtual_object_title
       )
     end
   end

--- a/spec/features/preassembly/preassembly_gis_raster_accessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_gis_raster_accessioning_spec.rb
@@ -8,8 +8,8 @@
 RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage', type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_gis_raster_accessioning' }
-    let(:object_label) { test_data[:title] }
-    let(:expected_text) { object_label }
+    let(:title) { test_data[:title] }
+    let(:expected_text) { title }
     let(:preassembly_bundle_dir) { Settings.preassembly.gis_bundle_directory }
     let(:content_type) { 'Geo' }
     let(:navigate_to_job_details) { :click_first_link }

--- a/spec/features/preassembly/preassembly_gis_vector_accessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_gis_vector_accessioning_spec.rb
@@ -8,8 +8,8 @@
 RSpec.describe 'Create gis object via Pre-assembly', if: $sdr_env == 'stage', type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_gis_vector_accessioning' }
-    let(:object_label) { test_data[:title] }
-    let(:expected_text) { object_label }
+    let(:title) { test_data[:title] }
+    let(:expected_text) { title }
     let(:preassembly_bundle_dir) { Settings.preassembly.gis_bundle_directory }
     let(:content_type) { 'Geo' }
     let(:navigate_to_job_details) { :click_first_link }

--- a/spec/features/preassembly/preassembly_hfs_accessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_hfs_accessioning_spec.rb
@@ -8,8 +8,8 @@ require 'druid-tools'
 RSpec.describe 'Create and re-accession object with hierarchical files via Pre-assembly', type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_hfs_accessioning' }
-    let(:object_label) { test_data[:title] }
-    let(:expected_text) { object_label }
+    let(:title) { test_data[:title] }
+    let(:expected_text) { title }
     let(:preassembly_bundle_dir) { Settings.preassembly.hfs_bundle_directory }
     let(:content_type) { 'File' }
     let(:navigate_to_job_details) { :click_first_link }
@@ -45,7 +45,7 @@ RSpec.describe 'Create and re-accession object with hierarchical files via Pre-a
 
       # This section confirms the object has been published to PURL and has filenames in the json
       expect_text_on_purl_page(druid:, text: collection_name)
-      expect_text_on_purl_page(druid:, text: object_label)
+      expect_text_on_purl_page(druid:, text: title)
 
       # verify the cocina json has the filenames with paths
       expect_published_files(druid:, filenames: ['README.md', 'config/settings.yml', 'config/settings/qa.yml',

--- a/spec/features/preassembly/preassembly_ocr_document_spec.rb
+++ b/spec/features/preassembly/preassembly_ocr_document_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRe
                                                                                     type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_ocr_document' }
-    let(:object_label) { test_data[:title] }
-    let(:expected_text) { object_label }
+    let(:title) { test_data[:title] }
+    let(:expected_text) { title }
     let(:preassembly_bundle_dir) { Settings.preassembly.ocr_document_bundle_directory }
     let(:content_type) { 'Document/PDF' }
     let(:ocr_settings) { { manually_corrected_ocr: false, run_ocr: true } }
@@ -75,7 +75,7 @@ RSpec.describe 'Create a document object via Pre-assembly and ask for it be OCRe
 
       # This section confirms the object has been published to PURL
       expect_text_on_purl_page(druid:, text: collection_name)
-      expect_text_on_purl_page(druid:, text: object_label)
+      expect_text_on_purl_page(druid:, text: title)
     end
   end
 end

--- a/spec/features/preassembly/preassembly_ocr_image_spec.rb
+++ b/spec/features/preassembly/preassembly_ocr_image_spec.rb
@@ -9,8 +9,8 @@ require 'druid-tools'
 RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed', if: Settings.ocr.enabled, type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_ocr_image' }
-    let(:object_label) { test_data[:title] }
-    let(:expected_text) { object_label }
+    let(:title) { test_data[:title] }
+    let(:expected_text) { title }
     let(:preassembly_bundle_dir) { Settings.preassembly.ocr_bundle_directory }
     let(:content_type) { 'Image' }
     let(:ocr_settings) { { ocr_available: false, run_ocr: true } }
@@ -75,7 +75,7 @@ RSpec.describe 'Create an image object via Pre-assembly and ask for it be OCRed'
       # valid IIIF manifest
       # wait for the PURL name to be published by checking for collection name
       expect_text_on_purl_page(druid:, text: collection_name)
-      expect_text_on_purl_page(druid:, text: object_label)
+      expect_text_on_purl_page(druid:, text: title)
       iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
       iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
       image_url = iiif_manifest.dig('sequences', 0, 'canvases', 0, 'images', 0, 'resource', '@id')

--- a/spec/features/preassembly/preassembly_reaccessioning_spec.rb
+++ b/spec/features/preassembly/preassembly_reaccessioning_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly', :sample_
   let(:start_url) { "#{Settings.argo_url}/view/#{druid}" }
   let(:bare_druid) { druid.delete_prefix('druid:') }
   let(:druid) { test_data[:druid] }
-  let(:object_label) { test_data[:title] }
+  let(:title) { test_data[:title] }
   let(:test_data) { load_test_data(spec_name: 'preassembly_accessioning') }
   let(:preassembly_bundle_dir) { Settings.preassembly.bundle_directory }
   let(:remote_manifest_location) do
@@ -33,7 +33,7 @@ RSpec.describe 'Create and re-accession image object via Pre-assembly', :sample_
   end
 
   before do
-    authenticate!(start_url:, expected_text: object_label)
+    authenticate!(start_url:, expected_text: title)
 
     # create manifest.csv file and scp it to preassembly staging directory
     File.write(local_manifest_location, preassembly_manifest_csv)

--- a/spec/features/preassembly/preassembly_speech_to_text_media_spec.rb
+++ b/spec/features/preassembly/preassembly_speech_to_text_media_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe 'Create a media object via Pre-assembly and ask for it be speechT
                                                                                           type: :preassembly do
   it_behaves_like 'preassembly job creation' do
     let(:spec_name) { 'preassembly_speech_to_text' }
-    let(:object_label) { test_data[:title] }
-    let(:expected_text) { object_label }
+    let(:title) { test_data[:title] }
+    let(:expected_text) { title }
     let(:preassembly_bundle_dir) { Settings.preassembly.speech_to_text_bundle_directory }
     let(:content_type) { 'Media' }
     let(:stt_settings) { { stt_available: false, run_stt: true } }
@@ -90,10 +90,10 @@ RSpec.describe 'Create a media object via Pre-assembly and ask for it be speechT
       # valid IIIF manifest
       # wait for the PURL name to be published by checking for collection name
       expect_text_on_purl_page(druid:, text: collection_name)
-      expect_text_on_purl_page(druid:, text: object_label)
+      expect_text_on_purl_page(druid:, text: title)
       iiif_manifest_url = find(:xpath, '//link[@rel="alternate" and @title="IIIF Manifest"]', visible: false)[:href]
       iiif_manifest = JSON.parse(Faraday.get(iiif_manifest_url).body)
-      expect(iiif_manifest['label']['en'].first).to eq object_label
+      expect(iiif_manifest['label']['en'].first).to eq title
     end
   end
 end

--- a/spec/features/sdr/web_archive_accessioning_spec.rb
+++ b/spec/features/sdr/web_archive_accessioning_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Use was-registrar-app, Argo, and pywb to ensure web archive craw
     select 'wasSeedPreassemblyWF', from: 'Initial Workflow'
     select 'webarchive-seed', from: 'Content Type'
     fill_in 'Source ID', with: "seed-#{source_id}"
-    fill_in 'Label', with: url_in_wayback
+    fill_in 'Title', with: url_in_wayback
     fill_in 'Tags', with: 'webarchive : seed'
     click_button 'Register'
 

--- a/spec/features/verify/goobi_accessioning_review_spec.rb
+++ b/spec/features/verify/goobi_accessioning_review_spec.rb
@@ -5,14 +5,13 @@
 RSpec.describe 'Verify object accessioned via Goobi', if: $sdr_env == 'stage', type: :verify do
   let(:druid) { test_data[:druid] }
   let(:bare_object_druid) { druid.delete_prefix('druid:') }
-  let(:object_label) { test_data[:label] }
+  let(:title) { test_data[:title] }
   let(:start_url) { "#{Settings.argo_url}/view/#{druid}" }
   let(:test_data) { load_test_data(spec_name: 'goobi_accessioning') }
   let(:collection_name) { 'integration-testing' }
 
   before do
-    authenticate!(start_url:,
-                  expected_text: object_label)
+    authenticate!(start_url:, expected_text: title)
   end
 
   after do
@@ -36,7 +35,7 @@ RSpec.describe 'Verify object accessioned via Goobi', if: $sdr_env == 'stage', t
     # wait for the PURL name to be published by checking for collection name
     expect_text_on_purl_page(druid:, text: collection_name)
     expect_text_on_purl_page(druid:, text: 'This work is licensed under an Apache License 2.0')
-    expect_text_on_purl_page(druid:, text: object_label)
+    expect_text_on_purl_page(druid:, text: title)
     expect_link_on_purl_page(druid:,
                              text: 'View in SearchWorks',
                              href: "#{Settings.searchworks_url}/view/#{bare_object_druid}")

--- a/spec/support/shared_examples/register_objects.rb
+++ b/spec/support/shared_examples/register_objects.rb
@@ -7,7 +7,7 @@
 #   it_behaves_like 'a register object action',
 #     object_id: [required: test name (i.e: access_indexing_spec, goobi_accessioning_spec, etc...)]
 #     source_id: [required],
-#     label: [required],
+#     title: [required],
 #     collection: [default: 'integration-testing'],
 #     apo: [default: 'integration-testing'],
 #     content_type: [default: nil],
@@ -22,7 +22,7 @@ RSpec.shared_examples 'an SDR object registion' do
   let(:workflow) { defined?(initial_workflow) ? initial_workflow : nil }
   let(:project_name) { defined?(project) ? project : nil }
   let(:project_tags) { defined?(tags) ? tags : nil }
-  let(:object_label) { "#{spec_name.humanize} object for #{random_phrase}" }
+  let(:title) { "#{spec_name.humanize} object for #{random_phrase}" }
   let(:default_source_id) { "#{spec_name.dasherize}:#{SecureRandom.uuid}" }
   let(:source_id) { defined?(virtual_source_id) ? virtual_source_id : default_source_id }
   let(:folio_instance_hrid) { defined?(folio_hrid) ? folio_hrid : nil }
@@ -46,7 +46,7 @@ RSpec.shared_examples 'an SDR object registion' do
 
     fill_in 'Source ID', with: source_id
     fill_in 'Folio Instance HRID', with: folio_instance_hrid if folio_instance_hrid
-    fill_in 'Label', with: object_label
+    fill_in 'Title', with: title
 
     click_button 'Register'
 
@@ -56,6 +56,6 @@ RSpec.shared_examples 'an SDR object registion' do
     bare_object_druid = find('table a').text
     druid = "druid:#{bare_object_druid}"
     puts " *** Registered druid: #{druid} ***" # useful for debugging
-    save_test_data(spec_name:, data: { 'druid' => druid, 'title' => object_label })
+    save_test_data(spec_name:, data: { 'druid' => druid, 'title' => title })
   end
 end


### PR DESCRIPTION
# Why was this change made?

Fixes #1019

- Replace all uses of 'object_label' with 'title' for consistency with application terminology and UI changes
- Update test variable names, let blocks, and method arguments to use 'title' instead of 'label'
- Change form field filling from 'Label' to 'Title' to match updated UI
- Adjust shared example documentation and data saving to use 'title'
- Improve clarity and alignment between test code and application fields
