### PR TITLE
more targeted reset workflow click

### DIFF
--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -57,7 +57,9 @@ module PageHelpers
         end
 
         if page.has_css?('.alert-danger', wait: 0) && page.has_text?(workflow_retry_text)
-          click_link_or_button workflow
+          within('#document-history-section') do
+            click_link_or_button workflow
+          end
           select 'Rerun', from: 'status'
           confirm_message = 'You have selected to manually change the status. '
           confirm_message += 'This could result in processing errors. Are you sure you want to proceed?'


### PR DESCRIPTION
## Why was this change made? 🤔

I believe this will have a more targeted click to reset workflows.  Designed to avoid this:

```
.....
    # ./spec/support/page_helpers.rb:60:in 'block (2 levels) in PageHelpers#reload_page_until_timeout_with_wf_step_retry!'
          # ./spec/support/page_helpers.rb:49:in 'block in PageHelpers#reload_page_until_timeout_with_wf_step_retry!'
          # ./spec/support/page_helpers.rb:48:in 'PageHelpers#reload_page_until_timeout_with_wf_step_retry!'
          # ./spec/features/preassembly/preassembly_ocr_document_spec.rb:35:in 'block (3 levels) in <top (required)>'
......

     1.2) Failure/Error: click_link_or_button workflow

          Capybara::Ambiguous:
            Ambiguous match, found 69 elements matching visible link or button
```

## Was README.md updated if necessary? 🤨


